### PR TITLE
Workaround PyTorch bug #39784

### DIFF
--- a/torchsde/_core/base_sde.py
+++ b/torchsde/_core/base_sde.py
@@ -81,7 +81,7 @@ class ForwardSDEIto(SDEIto):
             y = [y_.detach().requires_grad_(True) if not y_.requires_grad else y_ for y_ in y]
             val = self._base_sde.g(t, y)
             val = misc.make_seq_requires_grad(val)
-            vjp_val = torch.autograd.grad(
+            vjp_val = misc.grad(
                 outputs=val, inputs=y, grad_outputs=misc.seq_mul(val, v), create_graph=True, allow_unused=True)
             vjp_val = misc.convert_none_to_zeros(vjp_val, y)
         return vjp_val

--- a/torchsde/_core/methods/additive/adjoint_sde.py
+++ b/torchsde/_core/methods/additive/adjoint_sde.py
@@ -41,7 +41,7 @@ class AdjointSDEAdditive(base_sde.AdjointSDEIto):
             f_eval = [-f_eval_ for f_eval_ in f_eval]
             f_eval = misc.make_seq_requires_grad_y(f_eval, y)
 
-            vjp_y_and_params = torch.autograd.grad(
+            vjp_y_and_params = misc.grad(
                 outputs=f_eval,
                 inputs=y + params,
                 grad_outputs=[-adj_y_ for adj_y_ in adj_y],
@@ -66,7 +66,7 @@ class AdjointSDEAdditive(base_sde.AdjointSDEIto):
             g_eval = [-g_ for g_ in sde.g(-t, y)]
             g_eval = misc.make_seq_requires_grad_y(g_eval, y)
 
-            vjp_y_and_params = torch.autograd.grad(
+            vjp_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=[
                     -noise_.unsqueeze(1) * adj_y_.unsqueeze(2)  # Convert tensors to be of size (batch_size, d, m).
@@ -111,7 +111,7 @@ class AdjointSDEAdditiveLogqp(base_sde.AdjointSDEIto):
             f_eval = [-f_eval_ for f_eval_ in f_eval]
             f_eval = misc.make_seq_requires_grad_y(f_eval, y)
 
-            vjp_y_and_params = torch.autograd.grad(
+            vjp_y_and_params = misc.grad(
                 outputs=f_eval,
                 inputs=y + params,
                 grad_outputs=[-adj_y_ for adj_y_ in adj_y],
@@ -132,7 +132,7 @@ class AdjointSDEAdditiveLogqp(base_sde.AdjointSDEIto):
             u_eval = [torch.bmm(g_inv_eval_, u_eval_) for g_inv_eval_, u_eval_ in zip(g_inv_eval, u_eval)]
             log_ratio_correction = [.5 * torch.sum(u_eval_ ** 2., dim=1) for u_eval_ in u_eval]
             log_ratio_correction = misc.make_seq_requires_grad_y(log_ratio_correction, y)
-            corr_vjp_y_and_params = torch.autograd.grad(
+            corr_vjp_y_and_params = misc.grad(
                 outputs=log_ratio_correction, inputs=y + params,
                 grad_outputs=adj_l,
                 allow_unused=True,
@@ -159,7 +159,7 @@ class AdjointSDEAdditiveLogqp(base_sde.AdjointSDEIto):
             g_eval = [-g_ for g_ in sde.g(-t, y)]
             g_eval = misc.make_seq_requires_grad_y(g_eval, y)
 
-            vjp_y_and_params = torch.autograd.grad(
+            vjp_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=[-noise_.unsqueeze(1) * adj_y_.unsqueeze(2) for noise_, adj_y_ in zip(noise, adj_y)],
                 allow_unused=True,

--- a/torchsde/_core/methods/diagonal/adjoint_sde.py
+++ b/torchsde/_core/methods/diagonal/adjoint_sde.py
@@ -40,7 +40,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
             g_eval = sde.g(-t, y)
             g_eval = misc.make_seq_requires_grad_y(g_eval, y)
 
-            gdg = torch.autograd.grad(
+            gdg = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=g_eval,
                 allow_unused=True,
@@ -53,7 +53,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
             f_eval_corrected = misc.seq_sub(gdg, f_eval)  # Stratonovich correction for reverse-time.
             f_eval_corrected = misc.make_seq_requires_grad_y(f_eval_corrected, y)
 
-            vjp_y_and_params = torch.autograd.grad(
+            vjp_y_and_params = misc.grad(
                 outputs=f_eval_corrected,
                 inputs=y + params,
                 grad_outputs=[-adj_y_ for adj_y_ in adj_y],
@@ -65,7 +65,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
             vjp_params = vjp_y_and_params[n_tensors:]
             vjp_params = misc.flatten_convert_none_to_zeros(vjp_params, params)
 
-            adj_times_dgdx = torch.autograd.grad(
+            adj_times_dgdx = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=adj_y,
                 allow_unused=True,
@@ -74,7 +74,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
             adj_times_dgdx = misc.convert_none_to_zeros(adj_times_dgdx, y)
 
             # This extra term is due to converting the *adjoint* Stratonovich backward SDE to Itô.
-            extra_vjp_y_and_params = torch.autograd.grad(
+            extra_vjp_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=adj_times_dgdx,
                 allow_unused=True,
@@ -100,7 +100,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
 
             g_eval = [-g_ for g_ in sde.g(-t, y)]
             g_eval = misc.make_seq_requires_grad_y(g_eval, y)
-            vjp_y_and_params = torch.autograd.grad(
+            vjp_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=[-noise_ * adj_y_ for noise_, adj_y_ in zip(noise, adj_y)],
                 allow_unused=True,
@@ -124,7 +124,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
 
             g_eval = sde.g(-t, y)
             g_eval = misc.make_seq_requires_grad_y(g_eval, y)
-            gdg_times_v = torch.autograd.grad(
+            gdg_times_v = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=misc.seq_mul(g_eval, noise),
                 allow_unused=True,
@@ -132,7 +132,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
             )
             gdg_times_v = misc.convert_none_to_zeros(gdg_times_v, y)
 
-            dgdy = torch.autograd.grad(
+            dgdy = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=[torch.ones_like(y_) for y_ in y],
                 allow_unused=True,
@@ -140,7 +140,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
             )
             dgdy = misc.convert_none_to_zeros(dgdy, y)
 
-            prod_partials_adj_y_and_params = torch.autograd.grad(
+            prod_partials_adj_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=misc.seq_mul(adj_y, noise, dgdy),
                 allow_unused=True,
@@ -152,7 +152,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
             prod_partials_params = prod_partials_adj_y_and_params[n_tensors:]
             prod_partials_params = misc.flatten_convert_none_to_zeros(prod_partials_params, params)
 
-            gdg_v = torch.autograd.grad(
+            gdg_v = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=[p.detach() for p in misc.seq_mul(adj_y, noise, g_eval)],
                 allow_unused=True, create_graph=True
@@ -160,7 +160,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
             gdg_v = misc.convert_none_to_zeros(gdg_v, y)
             gdg_v = misc.make_seq_requires_grad_y(gdg_v, y)
 
-            mixed_partials_adj_y_and_params = torch.autograd.grad(
+            mixed_partials_adj_y_and_params = misc.grad(
                 outputs=gdg_v, inputs=y + params,
                 grad_outputs=[torch.ones_like(p) for p in gdg_v],
                 allow_unused=True,
@@ -202,7 +202,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             g_eval = sde.g(-t, y)
             g_eval = misc.make_seq_requires_grad_y(g_eval, y)
 
-            gdg = torch.autograd.grad(
+            gdg = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=g_eval,
                 allow_unused=True,
@@ -214,7 +214,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             f_eval_corrected = misc.seq_sub(gdg, f_eval)
             f_eval_corrected = misc.make_seq_requires_grad_y(f_eval_corrected, y)
 
-            vjp_y_and_params = torch.autograd.grad(
+            vjp_y_and_params = misc.grad(
                 outputs=f_eval_corrected, inputs=y + params,
                 grad_outputs=[-adj_y_ for adj_y_ in adj_y],
                 allow_unused=True,
@@ -225,7 +225,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             vjp_params = vjp_y_and_params[n_tensors:]
             vjp_params = misc.flatten_convert_none_to_zeros(vjp_params, params)
 
-            adj_times_dgdx = torch.autograd.grad(
+            adj_times_dgdx = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=adj_y,
                 allow_unused=True,
@@ -233,7 +233,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             )
             adj_times_dgdx = misc.convert_none_to_zeros(adj_times_dgdx, y)
 
-            extra_vjp_y_and_params = torch.autograd.grad(
+            extra_vjp_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=adj_times_dgdx,
                 allow_unused=True,
@@ -250,7 +250,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             log_ratio_correction = [.5 * torch.sum(u_eval_ ** 2., dim=1) for u_eval_ in u_eval]
 
             log_ratio_correction = misc.make_seq_requires_grad_y(log_ratio_correction, y)
-            corr_vjp_y_and_params = torch.autograd.grad(
+            corr_vjp_y_and_params = misc.grad(
                 outputs=log_ratio_correction, inputs=y + params,
                 grad_outputs=adj_l,
                 allow_unused=True,
@@ -279,7 +279,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             minus_g_eval = [-g_ for g_ in g_eval]
             minus_g_prod_eval = misc.seq_mul(minus_g_eval, noise)
 
-            vjp_y_and_params = torch.autograd.grad(
+            vjp_y_and_params = misc.grad(
                 outputs=minus_g_eval, inputs=y + params,
                 grad_outputs=[-noise_ * adj_y_ for noise_, adj_y_ in zip(noise, adj_y)],
                 allow_unused=True
@@ -303,7 +303,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             g_eval = sde.g(-t, y)
             g_eval = misc.make_seq_requires_grad_y(g_eval, y)
 
-            gdg_times_v = torch.autograd.grad(
+            gdg_times_v = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=misc.seq_mul(g_eval, noise),
                 allow_unused=True,
@@ -311,7 +311,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             )
             gdg_times_v = misc.convert_none_to_zeros(gdg_times_v, y)
 
-            dgdy = torch.autograd.grad(
+            dgdy = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=[torch.ones_like(y_) for y_ in y],
                 allow_unused=True,
@@ -319,7 +319,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             )
             dgdy = misc.convert_none_to_zeros(dgdy, y)
 
-            prod_partials_adj_y_and_params = torch.autograd.grad(
+            prod_partials_adj_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=misc.seq_mul(adj_y, noise, dgdy),
                 allow_unused=True,
@@ -330,7 +330,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             prod_partials_params = prod_partials_adj_y_and_params[n_tensors:]
             prod_partials_params = misc.flatten_convert_none_to_zeros(prod_partials_params, params)
 
-            gdg_v = torch.autograd.grad(
+            gdg_v = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=[p.detach() for p in misc.seq_mul(adj_y, noise, g_eval)],
                 allow_unused=True,
@@ -340,7 +340,7 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
             gdg_v = misc.make_seq_requires_grad_y(gdg_v, y)
 
             gdg_v = [gdg_v_.sum() for gdg_v_ in gdg_v]
-            mixed_partials_adj_y_and_params = torch.autograd.grad(
+            mixed_partials_adj_y_and_params = misc.grad(
                 outputs=gdg_v, inputs=y + params,
                 allow_unused=True,
             )

--- a/torchsde/_core/misc.py
+++ b/torchsde/_core/misc.py
@@ -153,3 +153,13 @@ def batch_mvp(m, v):
     mvp = torch.bmm(m, v)  # (batch_size, d, 1)
     mvp = mvp.squeeze(dim=-1)  # (batch_size, d)
     return mvp
+
+
+def grad(inputs, **kwargs):
+    # Workaround for PyTorch bug #39784
+    if torch.is_tensor(inputs):
+        inputs = (inputs,)
+    _inputs = []
+    for input in inputs:
+        _inputs.append(torch.as_strided(input, (), ()))
+    return torch.autograd.grad(inputs=inputs, **kwargs)

--- a/torchsde/_core/misc.py
+++ b/torchsde/_core/misc.py
@@ -159,7 +159,5 @@ def grad(inputs, **kwargs):
     # Workaround for PyTorch bug #39784
     if torch.is_tensor(inputs):
         inputs = (inputs,)
-    _inputs = []
-    for input in inputs:
-        _inputs.append(torch.as_strided(input, (), ()))
+    _inputs = [torch.as_strided(input, (), ()) for input in inputs]
     return torch.autograd.grad(inputs=inputs, **kwargs)

--- a/torchsde/_core/misc.py
+++ b/torchsde/_core/misc.py
@@ -159,5 +159,5 @@ def grad(inputs, **kwargs):
     # Workaround for PyTorch bug #39784
     if torch.is_tensor(inputs):
         inputs = (inputs,)
-    _inputs = [torch.as_strided(input, (), ()) for input in inputs]
+    _inputs = [torch.as_strided(input_, (), ()) for input_ in inputs]
     return torch.autograd.grad(inputs=inputs, **kwargs)


### PR DESCRIPTION
PyTorch has a bug when differentiating wrt unused inputs: https://github.com/pytorch/pytorch/issues/39784

If there are unused inputs that are unused globally, then it will backprop through the whole graph, even unrelated components. As such using the `allow_unused` flag is dangerous without this workaround.