### PR TITLE
Dev kidger2

### DIFF
--- a/diagnostics/ito_additive.py
+++ b/diagnostics/ito_additive.py
@@ -39,7 +39,7 @@ def inspect_samples():
 
     with torch.no_grad():
         bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(batch_size, m), dtype=y0.dtype, device=device,
-                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time)
         ys_em = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='euler')
         ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk')
         ys_true = sdeint(sde, y0=y0, ts=ts, dt=1e-3, bm=bm, method='euler')
@@ -76,7 +76,7 @@ def inspect_strong_order():
 
     with torch.no_grad():
         bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(batch_size, m), dtype=y0.dtype, device=device,
-                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time)
 
         for dt in tqdm.tqdm(dts):
             # Only take end value.

--- a/diagnostics/ito_additive.py
+++ b/diagnostics/ito_additive.py
@@ -14,6 +14,7 @@
 
 import os
 
+import argparse
 import matplotlib.pyplot as plt
 import torch
 import tqdm
@@ -22,7 +23,8 @@ from scipy import stats
 
 from tests.basic_sde import AdditiveSDE
 from tests.problems import Ex3Additive
-from torchsde import sdeint, BrownianPath
+from torchsde import sdeint, BrownianInterval
+from torchsde.settings import LEVY_AREA_APPROXIMATIONS
 from .utils import to_numpy, makedirs_if_not_found, compute_mse
 
 
@@ -31,15 +33,15 @@ def inspect_samples():
     steps = 10
 
     ts = torch.linspace(0., 5., steps=steps).to(device)
-    t0 = ts[0]
     dt = 3e-1
     y0 = torch.ones(batch_size, d).to(device)
     sde = AdditiveSDE(d=d, m=m).to(device)
 
     with torch.no_grad():
-        bm = BrownianPath(t0=t0, w0=torch.zeros(batch_size, m).to(device))
+        bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(batch_size, m), dtype=y0.dtype, device=device,
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
         ys_em = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='euler')
-        ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk', options={'trapezoidal_approx': False})
+        ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk')
         ys_true = sdeint(sde, y0=y0, ts=ts, dt=1e-3, bm=bm, method='euler')
 
         ys_em = ys_em.squeeze().t()
@@ -64,7 +66,7 @@ def inspect_samples():
 
 def inspect_strong_order():
     batch_size, d, m = 4096, 5, 5
-    t0, t1 = ts = torch.tensor([0., 5.]).to(device)
+    ts = torch.tensor([0., 5.]).to(device)
     dts = tuple(2 ** -i for i in range(1, 9))
     y0 = torch.ones(batch_size, d).to(device)
     sde = Ex3Additive(d=d).to(device)
@@ -73,12 +75,13 @@ def inspect_strong_order():
     srk_mses_ = []
 
     with torch.no_grad():
-        bm = BrownianPath(t0=t0, w0=torch.zeros(batch_size, m).to(device))  # It's important to have the correct size!!!
+        bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(batch_size, m), dtype=y0.dtype, device=device,
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
 
         for dt in tqdm.tqdm(dts):
             # Only take end value.
             _, ys_euler = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='euler')
-            _, ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk', options={'trapezoidal_approx': False})
+            _, ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk')
             _, ys_analytical = sde.analytical_sample(y0=y0, ts=ts, bm=bm)
 
             euler_mse = compute_mse(ys_euler, ys_analytical)
@@ -109,7 +112,11 @@ def inspect_strong_order():
 
 
 if __name__ == '__main__':
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--no-gpu', action='store_true')
+
+    args = parser.parse_args()
+    device = torch.device('cuda' if torch.cuda.is_available() and not args.no_gpu else 'cpu')
     torch.set_default_dtype(torch.float64)
     torch.manual_seed(0)
 

--- a/diagnostics/ito_diagonal.py
+++ b/diagnostics/ito_diagonal.py
@@ -38,7 +38,7 @@ def inspect_sample():
 
     with torch.no_grad():
         bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=y0.shape, dtype=y0.dtype, device=device,
-                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time)
 
         ys_euler = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='euler')
         ys_milstein = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='milstein')
@@ -82,7 +82,7 @@ def inspect_strong_order():
 
     with torch.no_grad():
         bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=y0.shape, dtype=y0.dtype, device=device,
-                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time)
 
         for dt in tqdm.tqdm(dts):
             # Only take end value.

--- a/diagnostics/ito_scalar.py
+++ b/diagnostics/ito_scalar.py
@@ -39,7 +39,7 @@ def inspect_sample():
 
     with torch.no_grad():
         bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(batch_size, 1), dtype=y0.dtype, device=device,
-                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time)
         ys_euler = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='euler')
         ys_milstein = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='milstein')
         ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk')
@@ -82,7 +82,7 @@ def inspect_strong_order():
 
     with torch.no_grad():
         bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(batch_size, 1), dtype=y0.dtype, device=device,
-                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time)
 
         for dt in tqdm.tqdm(dts):
             # Only take end value.

--- a/diagnostics/ito_scalar.py
+++ b/diagnostics/ito_scalar.py
@@ -14,6 +14,7 @@
 
 import os
 
+import argparse
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
@@ -21,7 +22,8 @@ import tqdm
 from scipy import stats
 
 from tests.problems import Ex2
-from torchsde import sdeint, BrownianPath
+from torchsde import sdeint, BrownianInterval
+from torchsde.settings import LEVY_AREA_APPROXIMATIONS
 from .utils import to_numpy, makedirs_if_not_found, compute_mse
 
 
@@ -30,17 +32,17 @@ def inspect_sample():
     steps = 100
 
     ts = torch.linspace(0., 5., steps=steps).to(device)
-    t0 = ts[0]
     dt = 1e-1
     y0 = torch.ones(batch_size, d).to(device)
     sde = Ex2(d=d).to(device)
     sde.noise_type = "scalar"
 
     with torch.no_grad():
-        bm = BrownianPath(t0=t0, w0=torch.zeros_like(y0))
+        bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(batch_size, 1), dtype=y0.dtype, device=device,
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
         ys_euler = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='euler')
         ys_milstein = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='milstein')
-        ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk', options={'trapezoidal_approx': False})
+        ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk')
         ys_analytical = sde.analytical_sample(y0=y0, ts=ts, bm=bm)
 
         ys_euler = ys_euler.squeeze().t()
@@ -69,7 +71,7 @@ def inspect_sample():
 
 def inspect_strong_order():
     batch_size, d = 4096, 10
-    t0, t1 = ts = torch.tensor([0., 5.]).to(device)
+    ts = torch.tensor([0., 5.]).to(device)
     dts = tuple(2 ** -i for i in range(1, 9))
     y0 = torch.ones(batch_size, d).to(device)
     sde = Ex2(d=d).to(device)
@@ -79,13 +81,14 @@ def inspect_strong_order():
     srk_mses_ = []
 
     with torch.no_grad():
-        bm = BrownianPath(t0=t0, w0=torch.zeros(batch_size, 1).to(device))
+        bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(batch_size, 1), dtype=y0.dtype, device=device,
+                              levy_area_approximation=LEVY_AREA_APPROXIMATIONS.spacetime)
 
         for dt in tqdm.tqdm(dts):
             # Only take end value.
             _, ys_euler = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='euler')
             _, ys_milstein = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='milstein')
-            _, ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk', options={'trapezoidal_approx': False})
+            _, ys_srk = sdeint(sde, y0=y0, ts=ts, dt=dt, bm=bm, method='srk')
             _, ys_analytical = sde.analytical_sample(y0=y0, ts=ts, bm=bm)
 
             euler_mse = compute_mse(ys_euler, ys_analytical)
@@ -120,7 +123,11 @@ def inspect_strong_order():
 
 
 if __name__ == '__main__':
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--no-gpu', action='store_true')
+
+    args = parser.parse_args()
+    device = torch.device('cuda' if torch.cuda.is_available() and not args.no_gpu else 'cpu')
     torch.set_default_dtype(torch.float64)
     torch.manual_seed(0)
 

--- a/examples/jit.py
+++ b/examples/jit.py
@@ -46,7 +46,7 @@ ts = torch.linspace(0, 1, 20)
 
 
 def time_func():
-    ys = sdeint(geometric_bm, y0, ts, adaptive=False, dt=ts[1], options={'trapezoidal_approx': True})
+    sdeint(geometric_bm, y0, ts, adaptive=False, dt=ts[1])
 
 
 print(timeit.Timer(time_func).timeit(number=100))

--- a/examples/latent_sde.py
+++ b/examples/latent_sde.py
@@ -27,7 +27,7 @@ from torch import nn, optim
 from torch.distributions import Normal, Laplace, kl_divergence
 
 from examples import utils
-from torchsde import sdeint, sdeint_adjoint, SDEIto, BrownianPath
+from torchsde import sdeint, sdeint_adjoint, SDEIto, BrownianInterval
 
 Data = namedtuple('Data', ['ts_', 'ts_ext_', 'ts_vis_', 'ts', 'ts_ext', 'ts_vis', 'ys', 'ys_'])
 
@@ -83,15 +83,11 @@ class LatentSDE(SDEIto):
         logqp0 = kl_divergence(qy0, py0).sum(1).mean(0)  # KL(time=0).
 
         if args.adjoint:
-            zs, logqp = sdeint_adjoint(
-                self, y0, ts, logqp=True, method=args.method, dt=args.dt, adaptive=args.adaptive, rtol=args.rtol,
-                atol=args.atol
-            )
+            zs, logqp = sdeint_adjoint(self, y0, ts, logqp=True, method=args.method, dt=args.dt, adaptive=args.adaptive,
+                                       rtol=args.rtol, atol=args.atol)
         else:
-            zs, logqp = sdeint(
-                self, y0, ts, logqp=True, method=args.method, dt=args.dt, adaptive=args.adaptive, rtol=args.rtol,
-                atol=args.atol
-            )
+            zs, logqp = sdeint(self, y0, ts, logqp=True, method=args.method, dt=args.dt, adaptive=args.adaptive,
+                               rtol=args.rtol, atol=args.atol)
         logqp = logqp.sum(0).mean(0)
         log_ratio = logqp0 + logqp  # KL(time=0) + KL(path).
 
@@ -175,7 +171,8 @@ def main():
 
     # Fix seed for the random draws used in the plots.
     eps = torch.randn(vis_batch_size, 1).to(device)
-    bm = BrownianPath(t0=ts_vis[0], w0=torch.zeros(vis_batch_size, 1).to(device))
+    bm = BrownianInterval(t0=ts_vis[0], t1=ts_vis[-1], shape=(vis_batch_size, 1), dtype=torch.float32, device=device,
+                          levy_area_approximation='space-time')  # We need space-time Levy area to use the SRK solver
 
     # Model.
     model = LatentSDE().to(device)

--- a/examples/latent_sde.py
+++ b/examples/latent_sde.py
@@ -82,16 +82,15 @@ class LatentSDE(SDEIto):
         py0 = Normal(loc=self.py0_mean, scale=self.py0_std)
         logqp0 = kl_divergence(qy0, py0).sum(1).mean(0)  # KL(time=0).
 
-        # `trapezoidal_approx` is for SRK. Disabling it gives better performance.
         if args.adjoint:
             zs, logqp = sdeint_adjoint(
                 self, y0, ts, logqp=True, method=args.method, dt=args.dt, adaptive=args.adaptive, rtol=args.rtol,
-                atol=args.atol, options={'trapezoidal_approx': False}
+                atol=args.atol
             )
         else:
             zs, logqp = sdeint(
                 self, y0, ts, logqp=True, method=args.method, dt=args.dt, adaptive=args.adaptive, rtol=args.rtol,
-                atol=args.atol, options={'trapezoidal_approx': False}
+                atol=args.atol
             )
         logqp = logqp.sum(0).mean(0)
         log_ratio = logqp0 + logqp  # KL(time=0) + KL(path).

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -73,7 +73,7 @@ class Ex2(SDEIto):
     def g(self, t, y):
         del t
         self._nfe += 1
-        return self.p * torch.cos(y) ** 2.
+        return self.p * torch.cos(y) ** 2
 
     def analytical_grad(self, y0, t, grad_output, bm):
         with torch.no_grad():

--- a/torchsde/_brownian/base_brownian.py
+++ b/torchsde/_brownian/base_brownian.py
@@ -19,7 +19,7 @@ from .._core import better_abc
 
 class BaseBrownian(metaclass=better_abc.ABCMeta):
     @abc.abstractmethod
-    def __call__(self, ta, tb):
+    def __call__(self, ta, tb, return_U, return_A):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/torchsde/_brownian/brownian_interval.py
+++ b/torchsde/_brownian/brownian_interval.py
@@ -446,7 +446,7 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
         self.levy_area_approximation = levy_area_approximation
 
         # Precompute these as we don't want to spend lots of time checking strings in hot loops.
-        self.have_H = self.levy_area_approximation in (LEVY_AREA_APPROXIMATIONS.spacetime,
+        self.have_H = self.levy_area_approximation in (LEVY_AREA_APPROXIMATIONS.space_time,
                                                        LEVY_AREA_APPROXIMATIONS.davie,
                                                        LEVY_AREA_APPROXIMATIONS.foster)
         self.have_A = self.levy_area_approximation in (LEVY_AREA_APPROXIMATIONS.davie,

--- a/torchsde/_brownian/brownian_interval.py
+++ b/torchsde/_brownian/brownian_interval.py
@@ -438,7 +438,8 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
         self._w_h = (W, H)
 
         if levy_area_approximation not in LEVY_AREA_APPROXIMATIONS:
-            raise ValueError(f"`levy_area_approximation` must be one of {LEVY_AREA_APPROXIMATIONS}.")
+            raise ValueError(f"`levy_area_approximation` must be one of {LEVY_AREA_APPROXIMATIONS}, but got "
+                             f"'{levy_area_approximation}'.")
 
         self._dt = None
         self._cache_size = cache_size
@@ -467,12 +468,15 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
     def _increment_and_space_time_levy_area(self):
         return self._w_h
 
-    def __call__(self, ta, tb):
+    # TODO: pick better names for return_U, return_A. A is clearly 'levy_area', but U?
+    def __call__(self, ta, tb=None, return_U=False, return_A=False):
+        if tb is None:
+            ta, tb = self.start, ta
         ta = float(ta)
         tb = float(tb)
         # Can get queries just inside and outside the specified region in SDE solvers; we just clamp.
-        ta = min(self.start, max(ta, self.end))
-        tb = min(self.start, max(tb, self.end))
+        ta = max(self.start, min(ta, self.end))
+        tb = max(self.start, min(tb, self.end))
         if ta > tb:
             raise RuntimeError(f"Query times ta={ta:.3f} and tb={tb:.3f} must respect ta <= tb.")
 
@@ -520,11 +524,16 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
         if self.have_H:
             U = (tb - ta) * (H + 0.5 * W)
 
-        if self.levy_area_approximation == LEVY_AREA_APPROXIMATIONS.none:
-            return W
-        elif self.levy_area_approximation == LEVY_AREA_APPROXIMATIONS.spacetime:
-            return W, U
-        return W, U, A
+        if return_U:
+            if return_A:
+                return W, U, A
+            else:
+                return W, U
+        else:
+            if return_A:
+                return W, A
+            else:
+                return W
 
     def _create_dependency_tree(self, dt):
         self._dt = dt

--- a/torchsde/_brownian/brownian_path.py
+++ b/torchsde/_brownian/brownian_path.py
@@ -52,8 +52,8 @@ class BrownianPath(base_brownian.BaseBrownian):
             w0: Initial state.
             window_size: Size of the window around the last query for local search.
             levy_area_approximation: Whether to also approximate Levy area. Defaults to None. Valid options are
-                either 'none', 'spacetime', 'davie' or 'foster', corresponding to approximation type. This is needed for
-                some higher-order SDE solvers.
+                either 'none', 'space-time', 'davie' or 'foster', corresponding to approximation type. This is needed
+                for some higher-order SDE solvers.
         """
         super(BrownianPath, self).__init__(**kwargs)
         if not utils.is_scalar(t0):
@@ -73,10 +73,24 @@ class BrownianPath(base_brownian.BaseBrownian):
         self._window_size = window_size
         self.levy_area_approximation = levy_area_approximation
 
-    def __call__(self, ta, tb=None):
+    def __call__(self, ta, tb=None, return_U=False, return_A=False):
         if tb is None:
-            return self.call(ta)
-        return self.call(tb) - self.call(ta)
+            W = self.call(ta)
+        else:
+            W = self.call(tb) - self.call(ta)
+        U = None
+        A = None
+
+        if return_U:
+            if return_A:
+                return W, U, A
+            else:
+                return W, U
+        else:
+            if return_A:
+                return W, A
+            else:
+                return W
 
     def call(self, t):
         t = float(t)

--- a/torchsde/_brownian/brownian_tree.py
+++ b/torchsde/_brownian/brownian_tree.py
@@ -79,7 +79,7 @@ class BrownianTree(base_brownian.BaseBrownian):
                 adaptive solver querying time points beyond initial and
                 terminal times.
             levy_area_approximation: Whether to also approximate Levy area.
-                Defaults to None. Valid options are either 'none', 'spacetime',
+                Defaults to None. Valid options are either 'none', 'space-time',
                 'davie' or 'foster', corresponding to approximation type. This
                 is needed for some higher-order SDE solvers.
         """
@@ -138,10 +138,24 @@ class BrownianTree(base_brownian.BaseBrownian):
 
         self._last_depth = None
 
-    def __call__(self, ta, tb=None):
+    def __call__(self, ta, tb=None, return_U=False, return_A=False):
         if tb is None:
-            return self.call(ta)
-        return self.call(tb) - self.call(ta)
+            W = self.call(ta)
+        else:
+            W = self.call(tb) - self.call(ta)
+        U = None
+        A = None
+
+        if return_U:
+            if return_A:
+                return W, U, A
+            else:
+                return W, U
+        else:
+            if return_A:
+                return W, A
+            else:
+                return W
 
     def call(self, t):
         t = float(t)

--- a/torchsde/_brownian/modified.py
+++ b/torchsde/_brownian/modified.py
@@ -45,15 +45,36 @@ class _ModifiedBrownian(base_brownian.BaseBrownian):
         return self.base_brownian.levy_area_approximation
 
 
+# TODO: these checks are very inelegant. Is there a better interface to Brownian motion?
 class ReverseBrownian(_ModifiedBrownian):
-    def __call__(self, ta, tb):
-        if self.levy_area_approximation == LEVY_AREA_APPROXIMATIONS.none:
-            return tuple(-b for b in self.base_brownian(-tb, -ta))
+    def __call__(self, ta, tb, return_U=False, return_A=False):
+        # TODO: double-check that this is the correct way to reverse each of
+        #  these objects
+        if return_U:
+            if return_A:
+                tuple((-W, U, A) for W, U, A in self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A))
+            else:
+                tuple((-W, U) for W, U in self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A))
         else:
-            return tuple((-b, -h, a) for b, h, a in self.base_brownian(-tb, -ta))
+            if return_A:
+                tuple((-W, A) for W, A in self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A))
+            else:
+                tuple(-W for W in self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A))
 
 
 class TupleBrownian(_ModifiedBrownian):
-    def __call__(self, ta, tb):
-        return (self.base_brownian(ta, tb),)
-
+    def __call__(self, ta, tb, return_U=False, return_A=False):
+        if return_U:
+            if return_A:
+                W, U, A = self.base_brownian(ta, tb, return_U=return_U, return_A=return_A)
+                return (W,), (U,), (A,)
+            else:
+                W, U = self.base_brownian(ta, tb, return_U=return_U, return_A=return_A)
+                return (W,), (U,)
+        else:
+            if return_A:
+                W, A = self.base_brownian(ta, tb, return_U=return_U, return_A=return_A)
+                return (W,), (A,)
+            else:
+                W = self.base_brownian(ta, tb, return_U=return_U, return_A=return_A)
+                return (W,)

--- a/torchsde/_brownian/modified.py
+++ b/torchsde/_brownian/modified.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..settings import LEVY_AREA_APPROXIMATIONS
-
 from . import base_brownian
 
 
@@ -48,18 +46,21 @@ class _ModifiedBrownian(base_brownian.BaseBrownian):
 # TODO: these checks are very inelegant. Is there a better interface to Brownian motion?
 class ReverseBrownian(_ModifiedBrownian):
     def __call__(self, ta, tb, return_U=False, return_A=False):
-        # TODO: double-check that this is the correct way to reverse each of
-        #  these objects
+        # TODO: double-check if U and A need reversing
         if return_U:
             if return_A:
-                tuple((-W, U, A) for W, U, A in self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A))
+                W, U, A = self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A)
+                return tuple(-W_ for W_ in W), U, A
             else:
-                tuple((-W, U) for W, U in self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A))
+                W, U = self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A)
+                return tuple(-W_ for W_ in W), U
         else:
             if return_A:
-                tuple((-W, A) for W, A in self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A))
+                W, A = self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A)
+                return tuple(-W_ for W_ in W), A
             else:
-                tuple(-W for W in self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A))
+                W = self.base_brownian(-tb, -ta, return_U=return_U, return_A=return_A)
+                return tuple(-W_ for W_ in W)
 
 
 class TupleBrownian(_ModifiedBrownian):

--- a/torchsde/_brownian/utils.py
+++ b/torchsde/_brownian/utils.py
@@ -104,7 +104,7 @@ _rsqrt3 = 1 / math.sqrt(3)
 
 
 def space_time_levy_area(W, h, levy_area_approximation, get_noise):
-    if levy_area_approximation in (LEVY_AREA_APPROXIMATIONS.spacetime,
+    if levy_area_approximation in (LEVY_AREA_APPROXIMATIONS.space_time,
                                    LEVY_AREA_APPROXIMATIONS.davie,
                                    LEVY_AREA_APPROXIMATIONS.foster):
         return h / 2. * (W + get_noise() * math.sqrt(h) * _rsqrt3)
@@ -113,7 +113,7 @@ def space_time_levy_area(W, h, levy_area_approximation, get_noise):
 
 
 def davie_foster_approximation(W, H, h, levy_area_approximation, get_noise):
-    if levy_area_approximation in (LEVY_AREA_APPROXIMATIONS.none, LEVY_AREA_APPROXIMATIONS.spacetime):
+    if levy_area_approximation in (LEVY_AREA_APPROXIMATIONS.none, LEVY_AREA_APPROXIMATIONS.space_time):
         return None
     elif W.shape == ():
         return torch.zeros_like(W)

--- a/torchsde/_core/adjoint.py
+++ b/torchsde/_core/adjoint.py
@@ -46,7 +46,7 @@ class _SdeintAdjointMethod(torch.autograd.Function):
         ctx.dt_min = dt_min
         ctx.adjoint_options = adjoint_options
 
-        sde = base_sde.ForwardSDEIto(sde)
+        sde = base_sde.ForwardSDE(sde)
         ans = sdeint.integrate(
             sde=sde,
             y0=y0,
@@ -133,7 +133,7 @@ class _SdeintLogqpAdjointMethod(torch.autograd.Function):
         ctx.dt_min = dt_min
         ctx.adjoint_options = adjoint_options
 
-        sde = base_sde.ForwardSDEIto(sde)
+        sde = base_sde.ForwardSDE(sde)
         ans_and_logqp = sdeint.integrate(
             sde=sde,
             y0=y0,

--- a/torchsde/_core/adjoint.py
+++ b/torchsde/_core/adjoint.py
@@ -283,19 +283,8 @@ def sdeint_adjoint(sde,
     if not isinstance(sde, nn.Module):
         raise ValueError('sde is required to be an instance of nn.Module.')
 
-    names_to_change = sdeint.get_names_to_change(names)
-    if len(names_to_change) > 0:
-        sde = base_sde.RenameMethodsSDE(sde, **names_to_change)
-    sdeint.check_contract(sde=sde, method=method, logqp=logqp, adjoint_method=adjoint_method)
-
-    if bm is None:
-        bm = BrownianPath(t0=ts[0], w0=torch.zeros_like(y0).cpu())
-
-    tensor_input = isinstance(y0, torch.Tensor)
-    if tensor_input:
-        sde = base_sde.TupleSDE(sde)
-        y0 = (y0,)
-        bm = TupleBrownian(bm)
+    sde, y0, bm, tensor_input = sdeint.check_contract(sde=sde, method=method, logqp=logqp, ts=ts, y0=y0, bm=bm,
+                                                      names=names, adjoint_method=adjoint_method)
 
     flat_params = misc.flatten(sde.parameters())
     if logqp:

--- a/torchsde/_core/base_solver.py
+++ b/torchsde/_core/base_solver.py
@@ -32,7 +32,7 @@ class BaseSDESolver(metaclass=better_abc.ABCMeta):
     weak_order = better_abc.abstract_attribute()
     sde_type = better_abc.abstract_attribute()
     noise_types = better_abc.abstract_attribute()
-    levy_area_approximation = better_abc.abstract_attribute()
+    levy_area_approximations = better_abc.abstract_attribute()
 
     def __init__(self, sde, bm, y0, dt, adaptive, rtol, atol, dt_min, options, **kwargs):
         super(BaseSDESolver, self).__init__(**kwargs)
@@ -41,8 +41,9 @@ class BaseSDESolver(metaclass=better_abc.ABCMeta):
         assert sde.noise_type in self.noise_types, (
             f"SDE has noise type {sde.noise_type} but solver only supports noise types {self.noise_types}"
         )
-        assert bm.levy_area_approximation == self.levy_area_approximation, (
-            f"SDE solver requires levy_area_approximation='{self.levy_area_approximation}' set on the Brownian motion."
+        assert bm.levy_area_approximation in self.levy_area_approximations, (
+            f"SDE solver requires one of {self.levy_area_approximations} set as the `levy_area_approximation` on the "
+            f"Brownian motion."
         )
         if sde.noise_type == NOISE_TYPES.scalar and torch.Size(bm.shape[1:]).numel() != 1:
             raise ValueError('The Brownian motion for scalar SDEs must of dimension 1.')

--- a/torchsde/_core/methods/euler.py
+++ b/torchsde/_core/methods/euler.py
@@ -21,7 +21,7 @@ class Euler(base_solver.BaseSDESolver):
     weak_order = 1.0
     sde_type = SDE_TYPES.ito
     noise_types = (NOISE_TYPES.additive, NOISE_TYPES.diagonal, NOISE_TYPES.general, NOISE_TYPES.scalar)
-    levy_area_approximation = LEVY_AREA_APPROXIMATIONS.none
+    levy_area_approximations = LEVY_AREA_APPROXIMATIONS.all()
 
     def __init__(self, sde, **kwargs):
         if sde.noise_type == NOISE_TYPES.additive:

--- a/torchsde/_core/methods/midpoint.py
+++ b/torchsde/_core/methods/midpoint.py
@@ -24,7 +24,7 @@ class Midpoint(base_solver.BaseSDESolver):
     levy_area_approximations = LEVY_AREA_APPROXIMATIONS.all()
 
     def __init__(self, sde, **kwargs):
-        if self.sde.noise_type == NOISE_TYPES.general:
+        if sde.noise_type == NOISE_TYPES.general:
             self.strong_order = 0.5
         else:
             self.strong_order = 1.0

--- a/torchsde/_core/methods/midpoint.py
+++ b/torchsde/_core/methods/midpoint.py
@@ -21,7 +21,7 @@ class Midpoint(base_solver.BaseSDESolver):
     weak_order = 1.0
     sde_type = SDE_TYPES.stratonovich
     noise_types = (NOISE_TYPES.additive, NOISE_TYPES.diagonal, NOISE_TYPES.general, NOISE_TYPES.scalar)
-    levy_area_approximation = LEVY_AREA_APPROXIMATIONS.none
+    levy_area_approximations = LEVY_AREA_APPROXIMATIONS.all()
 
     def __init__(self, sde, **kwargs):
         if self.sde.noise_type == NOISE_TYPES.general:

--- a/torchsde/_core/methods/milstein.py
+++ b/torchsde/_core/methods/milstein.py
@@ -22,7 +22,7 @@ class Milstein(base_solver.BaseSDESolver):
     weak_order = 1.0
     sde_type = SDE_TYPES.ito
     noise_types = (NOISE_TYPES.additive, NOISE_TYPES.diagonal, NOISE_TYPES.scalar)
-    levy_area_approximation = LEVY_AREA_APPROXIMATIONS.none
+    levy_area_approximations = LEVY_AREA_APPROXIMATIONS.all()
 
     def step(self, t0, y0, dt):
         assert dt > 0, 'Underflow in dt {}'.format(dt)

--- a/torchsde/_core/methods/srk.py
+++ b/torchsde/_core/methods/srk.py
@@ -37,7 +37,7 @@ class SRK(base_solver.BaseSDESolver):
     weak_order = 1.5
     sde_type = SDE_TYPES.ito
     noise_types = (NOISE_TYPES.additive, NOISE_TYPES.diagonal, NOISE_TYPES.scalar)
-    levy_area_approximations = [LEVY_AREA_APPROXIMATIONS.spacetime,
+    levy_area_approximations = [LEVY_AREA_APPROXIMATIONS.space_time,
                                 LEVY_AREA_APPROXIMATIONS.davie,
                                 LEVY_AREA_APPROXIMATIONS.foster]
 

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -80,7 +80,7 @@ def sdeint(sde: [base_sde.BaseSDE],
     """
     sde, y0, bm, tensor_input = check_contract(sde=sde, method=method, logqp=logqp, ts=ts, y0=y0, bm=bm, names=names)
 
-    sde = base_sde.ForwardSDEIto(sde)
+    sde = base_sde.ForwardSDE(sde)
     results = integrate(
         sde=sde,
         y0=y0,

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -17,19 +17,15 @@ from typing import Optional, Dict, Any
 
 import torch
 
-try:
-    from ..brownian_lib import BrownianPath
-except Exception:  # noqa
-    from torchsde._brownian import BrownianPath  # noqa
-from .._brownian import BaseBrownian, TupleBrownian
-from ..settings import SDE_TYPES, NOISE_TYPES, METHODS
+from .._brownian import BaseBrownian, TupleBrownian, BrownianInterval
+from ..settings import SDE_TYPES, NOISE_TYPES, METHODS, LEVY_AREA_APPROXIMATIONS
 from ..types import TensorOrTensors, Scalar, Vector
 
 from . import base_sde
 from . import methods
 
 
-def sdeint(sde,
+def sdeint(sde: [base_sde.BaseSDE],
            y0: TensorOrTensors,
            ts: Vector,
            bm: Optional[BaseBrownian] = None,
@@ -45,7 +41,7 @@ def sdeint(sde,
     """Numerically integrate an Itô SDE.
 
     Args:
-        sde (object): Object with methods `f` and `g` representing the drift and
+        sde: Object with methods `f` and `g` representing the drift and
             diffusion. The output of `g` should be a single (or a tuple of)
             tensor(s) of size (batch_size, d) for diagonal noise SDEs or
             (batch_size, d, m) for SDEs of other noise types; d is the
@@ -54,10 +50,10 @@ def sdeint(sde,
         y0 (sequence of Tensor): Tensors for initial state.
         ts (Tensor or sequence of float): Query times in non-descending order.
             The state at the first time of `ts` should be `y0`.
-        bm (Brownian, optional): A `BrownianPath` or `BrownianTree` object.
-            Should return tensors of size (batch_size, m) for `__call__`.
-            Defaults to `BrownianPath` for diagonal noise on CPU.
-            Currently does not support tuple outputs yet.
+        bm (Brownian, optional): A 'BrownianInterval', `BrownianPath` or
+            `BrownianTree` object. Should return tensors of size (batch_size, m)
+            for `__call__`. Defaults to `BrownianInterval`. Currently does not
+            support tuple outputs yet.
         logqp (bool, optional): If `True`, also return the log-ratio penalty.
         method (str, optional): Name of numerical integration method.
         dt (float, optional): The constant step size or initial step size for
@@ -80,21 +76,9 @@ def sdeint(sde,
 
     Raises:
         ValueError: An error occurred due to unrecognized noise type/method,
-            or `sde` is missing required methods.
+            or if `sde` is missing required methods.
     """
-    names_to_change = get_names_to_change(names)
-    if len(names_to_change) > 0:
-        sde = base_sde.RenameMethodsSDE(sde, **names_to_change)
-    check_contract(sde=sde, method=method, logqp=logqp)
-
-    if bm is None:
-        bm = BrownianPath(t0=ts[0], w0=torch.zeros_like(y0).cpu())
-
-    tensor_input = isinstance(y0, torch.Tensor)
-    if tensor_input:
-        sde = base_sde.TupleSDE(sde)
-        y0 = (y0,)
-        bm = TupleBrownian(bm)
+    sde, y0, bm, tensor_input = check_contract(sde=sde, method=method, logqp=logqp, ts=ts, y0=y0, bm=bm, names=names)
 
     sde = base_sde.ForwardSDEIto(sde)
     results = integrate(
@@ -116,15 +100,14 @@ def sdeint(sde,
     return results
 
 
-def get_names_to_change(names):
+def check_contract(sde, method, logqp, ts, y0, bm, names, adjoint_method=None):
     if names is None:
-        return {}
+        names_to_change = {}
+    else:
+        names_to_change = {key: names[key] for key in ('drift', 'diffusion', 'prior_drift') if key in names}
+    if len(names_to_change) > 0:
+        sde = base_sde.RenameMethodsSDE(sde, **names_to_change)
 
-    keys = ('drift', 'diffusion', 'prior_drift')
-    return {key: names[key] for key in keys if key in names}
-
-
-def check_contract(sde, method, logqp, adjoint_method=None):
     required_funcs = ('f', 'g', 'h') if logqp else ('f', 'g')
     missing_funcs = [func for func in required_funcs if not hasattr(sde, func)]
     if len(missing_funcs) > 0:
@@ -145,9 +128,86 @@ def check_contract(sde, method, logqp, adjoint_method=None):
     if method not in METHODS:
         raise ValueError(f'Expected method in {METHODS}, but found {method}.')
 
+    tensor_input = torch.is_tensor(y0)
+    if tensor_input:
+        sde = base_sde.TupleSDE(sde)
+        y0 = (y0,)
+    if not isinstance(y0, tuple) or any(not torch.is_tensor(y0_) for y0_ in y0):
+        raise ValueError("y0 must be a Tensor or a tuple of Tensors.")
+
+    drift_shape = [fi.shape for fi in sde.f(ts[0], y0)]
+    diffusion_shape = [gi.shape for gi in sde.g(ts[0], y0)]
+
+    if len(drift_shape) != len(diffusion_shape) or len(drift_shape) != len(y0):
+        raise ValueError("drift, diffusion and y0 must all return the same number of Tensors.")
+
+    for drift_shape_, y0_ in zip(drift_shape, y0):
+        if drift_shape_ != y0_.shape:
+            raise ValueError(f"Drift must return a Tensor of the same shape as y0. Got drift shape {drift_shape_} but "
+                             f"y0 shape {y0_.shape}.")
+
+    noise_channels = diffusion_shape[0][-1]
+    if sde.noise_type in (NOISE_TYPES.additive, NOISE_TYPES.general, NOISE_TYPES.scalar):
+        batch_dimensions = diffusion_shape[0][:-2]
+        for drift_shape_, diffusion_shape_ in zip(drift_shape, diffusion_shape):
+            drift_shape_ = tuple(drift_shape_)
+            diffusion_shape_ = tuple(diffusion_shape_)
+            if len(drift_shape_) == 0:
+                raise ValueError("Drift must be of shape (..., state_channels), but got shape ().")
+            if len(diffusion_shape_) < 2:
+                raise ValueError(f"Diffusion must have shape (..., state_channels, noise_channels), but got shape "
+                                 f"{diffusion_shape_}.")
+            if drift_shape_ != diffusion_shape_[:-1]:
+                raise ValueError(f"Drift and diffusion shapes do not match. Got drift shape "
+                                 f"{drift_shape_}, meaning {drift_shape_[:-1]} batch dimensions and {drift_shape_[-1]} "
+                                 f"channel dimensions, but diffusion shape {diffusion_shape_}, meaning "
+                                 f"{diffusion_shape_[:-2]} batch dimensions, {diffusion_shape_[-2]} channel dimensions "
+                                 f"and {diffusion_shape_[-1]} noise dimension.")
+            if diffusion_shape_[:-2] != batch_dimensions:
+                raise ValueError("Every Tensor return by the diffusion must have the same number and size of batch "
+                                 "dimensions.")
+            if diffusion_shape_[-1] != noise_channels:
+                raise ValueError("Every Tensor return by the diffusion must have the same number of noise channels.")
+        if sde.noise_type == NOISE_TYPES.scalar:
+            if noise_channels != 1:
+                raise ValueError(f"Scalar noise must have only one channel; the diffusion has {noise_channels} noise "
+                                 f"channels.")
+    else:   # sde.noise_type == NOISE_TYPES.diagonal
+        batch_dimensions = diffusion_shape[0][:-1]
+        for drift_shape_, diffusion_shape_ in zip(drift_shape, diffusion_shape):
+            drift_shape_ = tuple(drift_shape_)
+            diffusion_shape_ = tuple(diffusion_shape_)
+            if len(drift_shape_) == 0:
+                raise ValueError("Drift must be of shape (..., state_channels), but got shape ().")
+            if len(diffusion_shape_) == 0:
+                raise ValueError(f"Diffusion must have shape (..., state_channels), but got shape ().")
+            if drift_shape_ != diffusion_shape_:
+                raise ValueError(f"Drift and diffusion shapes do not match. Got drift shape "
+                                 f"{drift_shape_}, meaning {drift_shape_[:-1]} batch dimensions and {drift_shape_[-1]} "
+                                 f"channel dimensions, but diffusion shape {diffusion_shape_}, meaning "
+                                 f"{diffusion_shape_[:-1]} batch dimensions, {diffusion_shape_[-1]} channel dimensions "
+                                 f"and {diffusion_shape_[-1]} noise dimension.")
+            if diffusion_shape_[:-1] != batch_dimensions:
+                raise ValueError("Every Tensor return by the diffusion must have the same number and size of batch "
+                                 "dimensions.")
+            if diffusion_shape_[-1] != noise_channels:
+                raise ValueError("Every Tensor return by the diffusion must have the same number of noise channels.")
+
+    if bm is None:
+        if method == METHODS.srk:
+            levy_area_approximation = LEVY_AREA_APPROXIMATIONS.spacetime
+        else:
+            levy_area_approximation = LEVY_AREA_APPROXIMATIONS.none
+        bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(*batch_dimensions, noise_channels), dtype=y0[0].dtype,
+                              device=y0[0].device, levy_area_approximation=levy_area_approximation)
+    if tensor_input:
+        bm = TupleBrownian(bm)
+
     if adjoint_method is not None:
         if adjoint_method not in METHODS:
             raise ValueError(f'Expected adjoint_method in {METHODS}, but found {method}.')
+
+    return sde, y0, bm, tensor_input
 
 
 def integrate(sde, y0, ts, bm, method, dt, adaptive, rtol, atol, dt_min, options, logqp=False):

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -195,7 +195,7 @@ def check_contract(sde, method, logqp, ts, y0, bm, names, adjoint_method=None):
 
     if bm is None:
         if method == METHODS.srk:
-            levy_area_approximation = LEVY_AREA_APPROXIMATIONS.spacetime
+            levy_area_approximation = LEVY_AREA_APPROXIMATIONS.space_time
         else:
             levy_area_approximation = LEVY_AREA_APPROXIMATIONS.none
         bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(*batch_dimensions, noise_channels), dtype=y0[0].dtype,

--- a/torchsde/brownian_lib/brownian_path.py
+++ b/torchsde/brownian_lib/brownian_path.py
@@ -29,7 +29,7 @@ class BrownianPath(base_brownian.BaseBrownian):
 
     To use:
     >>> bm = BrownianPath(t0=0.0, w0=torch.zeros(4, 1))
-    >>> bm(0.5)
+    >>> bm(0., 0.5)
     tensor([[ 0.0733],
             [-0.5692],
             [ 0.1872],
@@ -52,10 +52,24 @@ class BrownianPath(base_brownian.BaseBrownian):
         self._bm = _BrownianPath(t0=t0, w0=w0)
         self.levy_area_approximation = levy_area_approximation
 
-    def __call__(self, ta, tb=None):
+    def __call__(self, ta, tb=None, return_U=False, return_A=False):
         if tb is None:
-            return self.call(ta)
-        return self.call(tb) - self.call(ta)
+            W = self.call(ta)
+        else:
+            W = self.call(tb) - self.call(ta)
+        U = None
+        A = None
+
+        if return_U:
+            if return_A:
+                return W, U, A
+            else:
+                return W, U
+        else:
+            if return_A:
+                return W, A
+            else:
+                return W
 
     def call(self, t):
         return self._bm(t)

--- a/torchsde/brownian_lib/brownian_tree.py
+++ b/torchsde/brownian_lib/brownian_tree.py
@@ -30,7 +30,7 @@ class BrownianTree(base_brownian. BaseBrownian):
 
     To use:
     >>> bm = BrownianTree(t0=0.0, w0=torch.zeros(4, 1))
-    >>> bm(0.5)
+    >>> bm(0., 0.5)
     tensor([[ 0.0733],
             [-0.5692],
             [ 0.1872],
@@ -102,10 +102,24 @@ class BrownianTree(base_brownian. BaseBrownian):
         self.safety = safety
         self.levy_area_approximation = levy_area_approximation
 
-    def __call__(self, ta, tb=None):
+    def __call__(self, ta, tb=None, return_U=False, return_A=False):
         if tb is None:
-            return self.call(ta)
-        return self.call(tb) - self.call(ta)
+            W = self.call(ta)
+        else:
+            W = self.call(tb) - self.call(ta)
+        U = None
+        A = None
+
+        if return_U:
+            if return_A:
+                return W, U, A
+            else:
+                return W, U
+        else:
+            if return_A:
+                return W, A
+            else:
+                return W
 
     def call(self, t):
         return self._bm(t)

--- a/torchsde/settings.py
+++ b/torchsde/settings.py
@@ -14,11 +14,14 @@
 
 
 class ContainerMeta(type):
+    def all(cls):
+        return sorted(getattr(cls, x) for x in dir(cls) if not x.startswith('__'))
+
     def __str__(cls):
-        return str(tuple(cls.__dict__.values()))
+        return str(cls.all())
 
     def __contains__(cls, item):
-        return item in cls.__dict__.values()
+        return item in cls.all()
 
 # TODO: consider moving all these enums into some appropriate section of the code, rather than having them be global
 #  like this. (e.g. instead set METHODS = {'euler': Euler, ...} in methods/__init__.py)

--- a/torchsde/settings.py
+++ b/torchsde/settings.py
@@ -48,6 +48,6 @@ class SDE_TYPES(metaclass=ContainerMeta):  # noqa
 
 class LEVY_AREA_APPROXIMATIONS(metaclass=ContainerMeta):  # noqa
     none = 'none'  # Don't compute any Levy area approximation
-    spacetime = 'space-time'  # Only compute an (exact) space-time Levy area
+    space_time = 'space-time'  # Only compute an (exact) space-time Levy area
     davie = 'davie'  # Compute Davie's approximation to Levy area
     foster = 'foster'  # Compute Foster's correction to Davie's approximation to Levy area


### PR DESCRIPTION
Quite a lot of bugfixes, mostly.

<details>
<summary>List</summary>

- Updated diagnostics.
- Removed trapezoidal_approx
- Fixed error messages for wrong methods etc.
- Can now call BrownianInterval with a single value.
- Fixed bug in BrownianInterval that it was always returning 0!
- There's now a 2-part way of getting levy area: it has to be set as available during `__init__`, and then specified that it's wanted during `__call__`. This allows one to create general Brownian motions that can be used in multiple solvers, and have each solver call just the bits it wants.
- Bugfix spacetime -> space-time
- Improved checking in check_contract
- Various minor tidy-ups
- Can use Brownian* with any Levy area sufficient for the solver, rather than just the minimum the solver needs.
- Fixed using bm=None in sdeint and sdeint_adjoint, so that it creates an appropriate BrownianInterval. This also makes method='srk' easy.
</details>

The diagnostics and `sdeint(bm=None)` both use BrownianInterval just because that's the only one offering `U` at the moment.

Also, whilst its not quite a formal test, the diagnostics seem positive about BrownianInterval; in particular it looks like SRK vs analytic is consistent, which implies that the space-time Levy area is likely correct wrt increment.

Btw, what name would you use for `U`? I'd describe it as "a cross term in the second order signature", but that's not very snappy and I'd like to replace `LEVY_AREA_APPROXIMATIONS.spacetime` with a more appropriate name.