### PR TITLE
Add efficient gdg_jvp term for log-ODE schemes.

### DIFF
--- a/tests/test_strat.py
+++ b/tests/test_strat.py
@@ -29,6 +29,13 @@ cpu, gpu = torch.device('cpu'), torch.device('cuda')
 device = gpu if torch.cuda.is_available() else cpu
 
 
+def _column_wise_func(y, t, i):
+    # This function is designed so that there are mixed partials.
+    return (torch.cos(y ** 2 * i + t * 0.1) +
+            torch.tan(y[..., 0:1] * y[..., -2:-1]) +
+            torch.sum(y ** 2, dim=-1, keepdim=True))
+
+
 class SDE(nn.Module):
 
     def __init__(self):
@@ -41,12 +48,43 @@ class SDE(nn.Module):
 
     def g(self, t, y):
         return [
-            torch.stack([torch.cos(y_ ** 2 * i + t * 0.1) for i in range(m)], dim=-1)
+            torch.stack([_column_wise_func(y_, t, i) for i in range(m)], dim=-1)
             for y_ in y
         ]
 
 
 batch_size, d, m = 3, 5, 12
+
+
+def _batch_jacobian(output, input_):
+    # Create batch of Jacobians for output of size (batch_size, d_o) and input of size (batch_size, d_i).
+    assert output.dim() == input_.dim() == 2
+    assert output.size(0) == input_.size(0)
+    jacs = []
+    for i in range(output.size(0)):  # batch_size.
+        jac = []
+        for j in range(output.size(1)):  # d_o.
+            grad, = torch.autograd.grad(output[i, j], input_, retain_graph=True, allow_unused=True)
+            grad = torch.zeros_like(input_[i]) if grad is None else grad[i].detach()
+            jac.append(grad)
+        jac = torch.stack(jac, dim=0)
+        jacs.append(jac)
+    return torch.stack(jacs, dim=0)
+
+
+def _gdg_jvp_brute_force(sde, t, y, a):
+    # TODO: Only checks the first input.
+    with torch.enable_grad():
+        y = [y_.detach().requires_grad_(True) if not y_.requires_grad else y_ for y_ in y]
+        g_eval = sde.g(t, y)
+        v = [torch.bmm(g_eval_, a_) for g_eval_, a_ in zip(g_eval, a)]
+
+        y0, g_eval0, v0 = y[0], g_eval[0], v[0]
+        num_brownian = g_eval0.size(-1)
+        jacobians_by_column = [_batch_jacobian(g_eval0[..., l], y0) for l in range(num_brownian)]
+        return [
+            sum(torch.bmm(jacobians_by_column[l], v0[..., l].unsqueeze(-1)).squeeze() for l in range(num_brownian))
+        ]
 
 
 def _make_inputs():
@@ -58,18 +96,20 @@ def _make_inputs():
     return sde, t, y, a
 
 
+def test_gdg_jvp():
+    sde, t, y, a = _make_inputs()
+    outs_full_jac = _gdg_jvp_brute_force(sde, t, y, a)  # Reference.
+    outs = sde.gdg_jvp_compute(t, y, a)
+    outs_v2 = sde.gdg_jvp_v2(t, y, a)
+    for out_full_jac, out, out_v2 in zip(outs_full_jac, outs, outs_v2):
+        assert torch.allclose(out_full_jac, out)
+        assert torch.allclose(out_full_jac, out_v2)
+
+
 def _time_function(func, reps=10):
     now = time.perf_counter()
     [func() for _ in range(reps)]
     return time.perf_counter() - now
-
-
-def test_gdg_jvp():
-    sde, t, y, a = _make_inputs()
-    outs = sde.gdg_jvp_compute(t, y, a)
-    outs_v2 = sde.gdg_jvp_v2(t, y, a)
-    for out, out_v2 in zip(outs, outs_v2):
-        assert torch.allclose(out, out_v2)
 
 
 def check_efficiency():

--- a/tests/test_strat.py
+++ b/tests/test_strat.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Temporary test for Stratonovich stuff.
+
+This should be eventually refactored and the file should be removed.
+"""
+
+import torch
+from torch import nn
+
+import time
+from torchsde._core.base_sde import ForwardSDE  # noqa
+from torchsde import settings
+
+torch.set_default_dtype(torch.float64)
+cpu, gpu = torch.device('cpu'), torch.device('cuda')
+device = gpu if torch.cuda.is_available() else cpu
+
+
+class SDE(nn.Module):
+
+    def __init__(self):
+        super(SDE, self).__init__()
+        self.noise_type = settings.NOISE_TYPES.general
+        self.sde_type = settings.SDE_TYPES.stratonovich
+
+    def f(self, t, y):
+        return [torch.sin(y_) + t for y_ in y]
+
+    def g(self, t, y):
+        return [
+            torch.stack([torch.cos(y_ ** 2 * i + t * 0.1) for i in range(m)], dim=-1)
+            for y_ in y
+        ]
+
+
+batch_size, d, m = 3, 5, 12
+
+
+def _make_inputs():
+    t = torch.rand(()).to(device)
+    y = [torch.randn(batch_size, d).to(device)]
+    a = torch.randn(batch_size, m, m).to(device)
+    a = [a - a.transpose(1, 2)]  # Anti-symmetric.
+    sde = ForwardSDE(base_sde=SDE())
+    return sde, t, y, a
+
+
+def _time_function(func, reps=10):
+    now = time.perf_counter()
+    [func() for _ in range(reps)]
+    return time.perf_counter() - now
+
+
+def test_gdg_jvp():
+    sde, t, y, a = _make_inputs()
+    outs = sde.gdg_jvp_compute(t, y, a)
+    outs_v2 = sde.gdg_jvp_v2(t, y, a)
+    for out, out_v2 in zip(outs, outs_v2):
+        assert torch.allclose(out, out_v2)
+
+
+def check_efficiency():
+    sde, t, y, a = _make_inputs()
+
+    func1 = lambda: sde.gdg_jvp_compute(t, y, a)  # Linear in m.
+    time_elapse = _time_function(func1)
+    print(f'Time elapse for loop: {time_elapse:.4f}')
+
+    func2 = lambda: sde.gdg_jvp_v2(t, y, a)  # Almost constant in m.
+    time_elapse = _time_function(func2)
+    print(f'Time elapse for duplicate: {time_elapse:.4f}')
+
+
+test_gdg_jvp()
+check_efficiency()

--- a/torchsde/_core/adjoint.py
+++ b/torchsde/_core/adjoint.py
@@ -46,7 +46,7 @@ class _SdeintAdjointMethod(torch.autograd.Function):
         ctx.dt_min = dt_min
         ctx.adjoint_options = adjoint_options
 
-        sde = base_sde.ForwardSDEIto(sde)
+        sde = base_sde.ForwardSDE(sde)
         ans = sdeint.integrate(
             sde=sde,
             y0=y0,
@@ -133,7 +133,7 @@ class _SdeintLogqpAdjointMethod(torch.autograd.Function):
         ctx.dt_min = dt_min
         ctx.adjoint_options = adjoint_options
 
-        sde = base_sde.ForwardSDEIto(sde)
+        sde = base_sde.ForwardSDE(sde)
         ans_and_logqp = sdeint.integrate(
             sde=sde,
             y0=y0,

--- a/torchsde/_core/adjoint_sdes/additive.py
+++ b/torchsde/_core/adjoint_sdes/additive.py
@@ -20,7 +20,7 @@ from .. import base_sde
 from .. import misc
 
 
-class AdjointSDEAdditive(base_sde.AdjointSDEIto):
+class AdjointSDEAdditive(base_sde.AdjointSDE):
 
     def __init__(self, sde, params):
         super(AdjointSDEAdditive, self).__init__(sde, noise_type="general")
@@ -90,7 +90,7 @@ class AdjointSDEAdditive(base_sde.AdjointSDEIto):
         raise NotImplementedError("This method shouldn't be called.")
 
 
-class AdjointSDEAdditiveLogqp(base_sde.AdjointSDEIto):
+class AdjointSDEAdditiveLogqp(base_sde.AdjointSDE):
     def __init__(self, sde, params):
         super(AdjointSDEAdditiveLogqp, self).__init__(sde, noise_type="general")
         self.params = params

--- a/torchsde/_core/adjoint_sdes/additive.py
+++ b/torchsde/_core/adjoint_sdes/additive.py
@@ -36,8 +36,6 @@ class AdjointSDEAdditive(base_sde.AdjointSDE):
 
             f_eval = sde.f(-t, y)
             f_eval = [-f_eval_ for f_eval_ in f_eval]
-            f_eval = misc.make_seq_requires_grad(f_eval)
-
             vjp_y_and_params = misc.grad(
                 outputs=f_eval,
                 inputs=y + params,
@@ -61,8 +59,6 @@ class AdjointSDEAdditive(base_sde.AdjointSDE):
             adj_y = [adj_y_.detach() for adj_y_ in adj_y]
 
             g_eval = [-g_ for g_ in sde.g(-t, y)]
-            g_eval = misc.make_seq_requires_grad(g_eval)
-
             vjp_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=[
@@ -106,8 +102,6 @@ class AdjointSDEAdditiveLogqp(base_sde.AdjointSDE):
 
             f_eval = sde.f(-t, y)
             f_eval = [-f_eval_ for f_eval_ in f_eval]
-            f_eval = misc.make_seq_requires_grad(f_eval)
-
             vjp_y_and_params = misc.grad(
                 outputs=f_eval,
                 inputs=y + params,
@@ -128,7 +122,6 @@ class AdjointSDEAdditiveLogqp(base_sde.AdjointSDE):
             u_eval = misc.seq_sub(f_eval, h_eval)
             u_eval = [torch.bmm(g_inv_eval_, u_eval_) for g_inv_eval_, u_eval_ in zip(g_inv_eval, u_eval)]
             log_ratio_correction = [.5 * torch.sum(u_eval_ ** 2., dim=1) for u_eval_ in u_eval]
-            log_ratio_correction = misc.make_seq_requires_grad(log_ratio_correction)
             corr_vjp_y_and_params = misc.grad(
                 outputs=log_ratio_correction, inputs=y + params,
                 grad_outputs=adj_l,
@@ -154,8 +147,6 @@ class AdjointSDEAdditiveLogqp(base_sde.AdjointSDE):
             adj_y = [adj_y_.detach() for adj_y_ in adj_y]
 
             g_eval = [-g_ for g_ in sde.g(-t, y)]
-            g_eval = misc.make_seq_requires_grad(g_eval)
-
             vjp_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=[-noise_.unsqueeze(1) * adj_y_.unsqueeze(2) for noise_, adj_y_ in zip(noise, adj_y)],

--- a/torchsde/_core/adjoint_sdes/diagonal.py
+++ b/torchsde/_core/adjoint_sdes/diagonal.py
@@ -34,8 +34,6 @@ class AdjointSDEDiagonal(base_sde.AdjointSDE):
             adj_y = [adj_y_.detach() for adj_y_ in adj_y]
 
             g_eval = sde.g(-t, y)
-            g_eval = misc.make_seq_requires_grad(g_eval)
-
             gdg = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=g_eval,
@@ -45,10 +43,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDE):
             gdg = misc.convert_none_to_zeros(gdg, y)
 
             f_eval = sde.f(-t, y)
-
             f_eval_corrected = misc.seq_sub(gdg, f_eval)  # Stratonovich correction for reverse-time.
-            f_eval_corrected = misc.make_seq_requires_grad(f_eval_corrected)
-
             vjp_y_and_params = misc.grad(
                 outputs=f_eval_corrected,
                 inputs=y + params,
@@ -95,7 +90,6 @@ class AdjointSDEDiagonal(base_sde.AdjointSDE):
             adj_y = [adj_y_.detach() for adj_y_ in adj_y]
 
             g_eval = [-g_ for g_ in sde.g(-t, y)]
-            g_eval = misc.make_seq_requires_grad(g_eval)
             vjp_y_and_params = misc.grad(
                 outputs=g_eval, inputs=y + params,
                 grad_outputs=[-noise_ * adj_y_ for noise_, adj_y_ in zip(noise, adj_y)],
@@ -119,7 +113,6 @@ class AdjointSDEDiagonal(base_sde.AdjointSDE):
             adj_y = [adj_y_.detach().requires_grad_(True) for adj_y_ in adj_y]
 
             g_eval = sde.g(-t, y)
-            g_eval = misc.make_seq_requires_grad(g_eval)
             gdg_times_v = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=misc.seq_mul(g_eval, noise),
@@ -154,8 +147,6 @@ class AdjointSDEDiagonal(base_sde.AdjointSDE):
                 allow_unused=True, create_graph=True
             )
             gdg_v = misc.convert_none_to_zeros(gdg_v, y)
-            gdg_v = misc.make_seq_requires_grad(gdg_v)
-
             mixed_partials_adj_y_and_params = misc.grad(
                 outputs=gdg_v, inputs=y + params,
                 grad_outputs=[torch.ones_like(p) for p in gdg_v],
@@ -196,8 +187,6 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDE):
             adj_y = [adj_y_.detach() for adj_y_ in adj_y]
 
             g_eval = sde.g(-t, y)
-            g_eval = misc.make_seq_requires_grad(g_eval)
-
             gdg = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=g_eval,
@@ -208,8 +197,6 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDE):
 
             f_eval = sde.f(-t, y)
             f_eval_corrected = misc.seq_sub(gdg, f_eval)
-            f_eval_corrected = misc.make_seq_requires_grad(f_eval_corrected)
-
             vjp_y_and_params = misc.grad(
                 outputs=f_eval_corrected, inputs=y + params,
                 grad_outputs=[-adj_y_ for adj_y_ in adj_y],
@@ -244,8 +231,6 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDE):
             h_eval = sde.h(-t, y)
             u_eval = misc.seq_sub_div(f_eval, h_eval, g_eval)
             log_ratio_correction = [.5 * torch.sum(u_eval_ ** 2., dim=1) for u_eval_ in u_eval]
-
-            log_ratio_correction = misc.make_seq_requires_grad(log_ratio_correction)
             corr_vjp_y_and_params = misc.grad(
                 outputs=log_ratio_correction, inputs=y + params,
                 grad_outputs=adj_l,
@@ -271,7 +256,6 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDE):
             adj_y = [adj_y_.detach() for adj_y_ in adj_y]
 
             g_eval = sde.g(-t, y)
-            g_eval = misc.make_seq_requires_grad(g_eval)
             minus_g_eval = [-g_ for g_ in g_eval]
             minus_g_prod_eval = misc.seq_mul(minus_g_eval, noise)
 
@@ -297,8 +281,6 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDE):
             adj_y = [adj_y_.detach().requires_grad_(True) for adj_y_ in adj_y]
 
             g_eval = sde.g(-t, y)
-            g_eval = misc.make_seq_requires_grad(g_eval)
-
             gdg_times_v = misc.grad(
                 outputs=g_eval, inputs=y,
                 grad_outputs=misc.seq_mul(g_eval, noise),
@@ -333,8 +315,6 @@ class AdjointSDEDiagonalLogqp(base_sde.AdjointSDE):
                 create_graph=True,
             )
             gdg_v = misc.convert_none_to_zeros(gdg_v, y)
-            gdg_v = misc.make_seq_requires_grad(gdg_v)
-
             gdg_v = [gdg_v_.sum() for gdg_v_ in gdg_v]
             mixed_partials_adj_y_and_params = misc.grad(
                 outputs=gdg_v, inputs=y + params,

--- a/torchsde/_core/adjoint_sdes/diagonal.py
+++ b/torchsde/_core/adjoint_sdes/diagonal.py
@@ -19,7 +19,7 @@ from .. import base_sde
 from .. import misc
 
 
-class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
+class AdjointSDEDiagonal(base_sde.AdjointSDE):
 
     def __init__(self, sde, params):
         super(AdjointSDEDiagonal, self).__init__(sde, noise_type="diagonal")
@@ -180,7 +180,7 @@ class AdjointSDEDiagonal(base_sde.AdjointSDEIto):
         raise NotImplementedError("This method shouldn't be called.")
 
 
-class AdjointSDEDiagonalLogqp(base_sde.AdjointSDEIto):
+class AdjointSDEDiagonalLogqp(base_sde.AdjointSDE):
 
     def __init__(self, sde, params):
         super(AdjointSDEDiagonalLogqp, self).__init__(sde, noise_type="diagonal")

--- a/torchsde/_core/adjoint_sdes/scalar.py
+++ b/torchsde/_core/adjoint_sdes/scalar.py
@@ -17,7 +17,7 @@
 from .. import base_sde
 
 
-class AdjointSDEScalar(base_sde.AdjointSDEIto):
+class AdjointSDEScalar(base_sde.AdjointSDE):
 
     def __init__(self, sde, params):
         super(AdjointSDEScalar, self).__init__(sde, noise_type="scalar")
@@ -39,7 +39,7 @@ class AdjointSDEScalar(base_sde.AdjointSDEIto):
         raise NotImplementedError("This method shouldn't be called.")
 
 
-class AdjointSDEScalarLogqp(base_sde.AdjointSDEIto):
+class AdjointSDEScalarLogqp(base_sde.AdjointSDE):
 
     def __init__(self, sde, params):
         super(AdjointSDEScalarLogqp, self).__init__(sde, noise_type="scalar")

--- a/torchsde/_core/base_sde.py
+++ b/torchsde/_core/base_sde.py
@@ -128,7 +128,6 @@ class ForwardSDE(BaseSDE):
         with torch.enable_grad():
             y = [y_.detach().requires_grad_(True) if not y_.requires_grad else y_ for y_ in y]
             val = self._base_sde.g(t, y)
-            val = misc.make_seq_requires_grad(val)
             vjp_val = misc.grad(
                 outputs=val,
                 inputs=y,

--- a/torchsde/_core/base_sde.py
+++ b/torchsde/_core/base_sde.py
@@ -17,8 +17,8 @@ import abc
 import torch
 from torch import nn
 
-from . import misc
 from torchsde import settings
+from . import misc
 
 
 class BaseSDE(abc.ABC, nn.Module):

--- a/torchsde/_core/methods/milstein.py
+++ b/torchsde/_core/methods/milstein.py
@@ -32,10 +32,7 @@ class Milstein(base_solver.BaseSDESolver):
 
         f_eval = self.sde.f(t0, y0)
         g_prod_eval = self.sde.g_prod(t0, y0, I_k)
-        if self.sde.noise_type == NOISE_TYPES.additive:
-            gdg_prod_eval = [0] * len(g_prod_eval)
-        else:
-            gdg_prod_eval = self.sde.gdg_prod(t0, y0, v)
+        gdg_prod_eval = self.sde.gdg_prod(t0, y0, v)
         y1 = [
             y0_i + f_eval_i * dt + g_prod_eval_i + .5 * gdg_prod_eval_i
             for y0_i, f_eval_i, g_prod_eval_i, gdg_prod_eval_i in zip(y0, f_eval, g_prod_eval, gdg_prod_eval)

--- a/torchsde/_core/misc.py
+++ b/torchsde/_core/misc.py
@@ -152,9 +152,21 @@ def batch_mvp(m, v):
     return mvp
 
 
-def grad(inputs, **kwargs):
+def grad(outputs, inputs, grad_outputs=None, **kwargs):
     # Workaround for PyTorch bug #39784
     if torch.is_tensor(inputs):
         inputs = (inputs,)
     _inputs = [torch.as_strided(input_, (), ()) for input_ in inputs]
-    return torch.autograd.grad(inputs=inputs, **kwargs)
+    return torch.autograd.grad(outputs, inputs, grad_outputs=grad_outputs, **kwargs)
+
+
+def jvp(outputs, inputs, grad_inputs=None, **kwargs):
+    # `torch.autograd.functional.jvp` takes in `func` and requires re-evaluation.
+    # The present implementation avoids this.
+    if torch.is_tensor(inputs):
+        inputs = (inputs,)
+    _inputs = [torch.as_strided(input_, (), ()) for input_ in inputs]
+
+    dummy = [torch.zeros_like(o, requires_grad=True) for o in outputs]
+    vjp = torch.autograd.grad(outputs, inputs, grad_outputs=dummy, **kwargs)
+    return torch.autograd.grad(vjp, dummy, grad_outputs=grad_inputs, **kwargs)

--- a/torchsde/_core/misc.py
+++ b/torchsde/_core/misc.py
@@ -152,13 +152,13 @@ def batch_mvp(m, v):
     return mvp
 
 
-def grad(outputs, inputs, grad_outputs=None, **kwargs):
+def grad(outputs, inputs, **kwargs):
     # Workaround for PyTorch bug #39784
     outputs = make_seq_requires_grad(outputs)
     if torch.is_tensor(inputs):
         inputs = (inputs,)
     _inputs = [torch.as_strided(input_, (), ()) for input_ in inputs]
-    return torch.autograd.grad(outputs, inputs, grad_outputs=grad_outputs, **kwargs)
+    return torch.autograd.grad(outputs, inputs, **kwargs)
 
 
 def jvp(outputs, inputs, grad_inputs=None, **kwargs):

--- a/torchsde/_core/misc.py
+++ b/torchsde/_core/misc.py
@@ -154,6 +154,7 @@ def batch_mvp(m, v):
 
 def grad(outputs, inputs, grad_outputs=None, **kwargs):
     # Workaround for PyTorch bug #39784
+    outputs = make_seq_requires_grad(outputs)
     if torch.is_tensor(inputs):
         inputs = (inputs,)
     _inputs = [torch.as_strided(input_, (), ()) for input_ in inputs]
@@ -163,6 +164,7 @@ def grad(outputs, inputs, grad_outputs=None, **kwargs):
 def jvp(outputs, inputs, grad_inputs=None, **kwargs):
     # `torch.autograd.functional.jvp` takes in `func` and requires re-evaluation.
     # The present implementation avoids this.
+    outputs = make_seq_requires_grad(outputs)
     if torch.is_tensor(inputs):
         inputs = (inputs,)
     _inputs = [torch.as_strided(input_, (), ()) for input_ in inputs]

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -96,7 +96,7 @@ def sdeint(sde,
         y0 = (y0,)
         bm = TupleBrownian(bm)
 
-    sde = base_sde.ForwardSDEIto(sde)
+    sde = base_sde.ForwardSDE(sde)
     results = integrate(
         sde=sde,
         y0=y0,


### PR DESCRIPTION
I've decided to go with the jvp implementation. 

I implemented two versions: One with better memory scaling and the other with better time scaling. I'll send some more discussions via email. 

I've only added a simple test. The numerical checks pass. The efficient version is much faster than the loop version on CPU. 