### PR TITLE
BrownianInterval tests + bugfixes

### DIFF
--- a/diagnostics/ito_additive.py
+++ b/diagnostics/ito_additive.py
@@ -118,7 +118,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     device = torch.device('cuda' if torch.cuda.is_available() and not args.no_gpu else 'cpu')
     torch.set_default_dtype(torch.float64)
-    torch.manual_seed(0)
+    torch.manual_seed(2147483647)
 
     inspect_samples()
     inspect_strong_order()

--- a/diagnostics/ito_additive.py
+++ b/diagnostics/ito_additive.py
@@ -118,7 +118,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     device = torch.device('cuda' if torch.cuda.is_available() and not args.no_gpu else 'cpu')
     torch.set_default_dtype(torch.float64)
-    torch.manual_seed(2147483647)
+    torch.manual_seed(1147481649)
 
     inspect_samples()
     inspect_strong_order()

--- a/diagnostics/ito_diagonal.py
+++ b/diagnostics/ito_diagonal.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     device = torch.device('cuda' if torch.cuda.is_available() and not args.no_gpu else 'cpu')
     torch.set_default_dtype(torch.float64)
-    torch.manual_seed(0)
+    torch.manual_seed(2147483647)
 
     inspect_sample()
     inspect_strong_order()

--- a/diagnostics/ito_diagonal.py
+++ b/diagnostics/ito_diagonal.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     device = torch.device('cuda' if torch.cuda.is_available() and not args.no_gpu else 'cpu')
     torch.set_default_dtype(torch.float64)
-    torch.manual_seed(2147483647)
+    torch.manual_seed(1147481649)
 
     inspect_sample()
     inspect_strong_order()

--- a/diagnostics/ito_scalar.py
+++ b/diagnostics/ito_scalar.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     device = torch.device('cuda' if torch.cuda.is_available() and not args.no_gpu else 'cpu')
     torch.set_default_dtype(torch.float64)
-    torch.manual_seed(0)
+    torch.manual_seed(2147483647)
 
     inspect_sample()
     inspect_strong_order()

--- a/diagnostics/ito_scalar.py
+++ b/diagnostics/ito_scalar.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     device = torch.device('cuda' if torch.cuda.is_available() and not args.no_gpu else 'cpu')
     torch.set_default_dtype(torch.float64)
-    torch.manual_seed(2147483647)
+    torch.manual_seed(1147481649)
 
     inspect_sample()
     inspect_strong_order()

--- a/diagnostics/profile_btree.py
+++ b/diagnostics/profile_btree.py
@@ -64,7 +64,7 @@ def main():
 
 if __name__ == "__main__":
     device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
-    torch.manual_seed(0)
+    torch.manual_seed(2147483647)
 
     reps = 500
     b, d = 512, 10

--- a/diagnostics/profile_btree.py
+++ b/diagnostics/profile_btree.py
@@ -64,7 +64,7 @@ def main():
 
 if __name__ == "__main__":
     device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
-    torch.manual_seed(2147483647)
+    torch.manual_seed(1147481649)
 
     reps = 500
     b, d = 512, 10

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -26,7 +26,7 @@ from tests.problems import Ex1, Ex2, Ex3, Ex3Additive
 from tests.torch_test import TorchTestCase
 from torchsde import BrownianPath, sdeint_adjoint
 
-torch.manual_seed(2147483647)
+torch.manual_seed(1147481649)
 torch.set_default_dtype(torch.float64)
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -26,7 +26,7 @@ from tests.problems import Ex1, Ex2, Ex3, Ex3Additive
 from tests.torch_test import TorchTestCase
 from torchsde import BrownianPath, sdeint_adjoint
 
-torch.manual_seed(0)
+torch.manual_seed(2147483647)
 torch.set_default_dtype(torch.float64)
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 

--- a/tests/test_adjoint_logqp.py
+++ b/tests/test_adjoint_logqp.py
@@ -24,7 +24,7 @@ from tests.basic_sde import BasicSDE1, BasicSDE2, BasicSDE3, BasicSDE4
 from tests.torch_test import TorchTestCase
 from torchsde import BrownianPath, sdeint_adjoint
 
-torch.manual_seed(2147483647)
+torch.manual_seed(1147481649)
 torch.set_default_dtype(torch.float64)
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 

--- a/tests/test_adjoint_logqp.py
+++ b/tests/test_adjoint_logqp.py
@@ -24,7 +24,7 @@ from tests.basic_sde import BasicSDE1, BasicSDE2, BasicSDE3, BasicSDE4
 from tests.torch_test import TorchTestCase
 from torchsde import BrownianPath, sdeint_adjoint
 
-torch.manual_seed(0)
+torch.manual_seed(2147483647)
 torch.set_default_dtype(torch.float64)
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 

--- a/tests/test_brownian_interval.py
+++ b/tests/test_brownian_interval.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the two `BrownianTree`.
+"""Test the `BrownianInterval``.
 
 The suite tests both running on CPU and CUDA (if available).
 """

--- a/tests/test_brownian_interval.py
+++ b/tests/test_brownian_interval.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the `BrownianInterval``.
+"""Test `BrownianInterval`.
 
 The suite tests both running on CPU and CUDA (if available).
 """

--- a/tests/test_brownian_interval.py
+++ b/tests/test_brownian_interval.py
@@ -194,7 +194,6 @@ def test_normality_conditional(device, levy_area_approximation):
         bm = torchsde.BrownianInterval(t0=t0, t1=t1, shape=(LARGE_BATCH_SIZE,),
                                        levy_area_approximation=levy_area_approximation, pool_size=POOL_SIZE)
 
-        # for _ in range(REPS):
         t_ = npr.uniform(low=t0_ + eps, high=t1_ - eps)
         ta = npr.uniform(low=t0_ + eps, high=t1_ - eps)
         tb = npr.uniform(low=t0_ + eps, high=t1_ - eps)

--- a/tests/test_brownian_interval.py
+++ b/tests/test_brownian_interval.py
@@ -1,0 +1,229 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the two `BrownianTree`.
+
+The suite tests both running on CPU and CUDA (if available).
+"""
+import sys
+
+sys.path = sys.path[1:]  # A hack so that we always import the installed library.
+
+import numpy as np
+import numpy.random as npr
+import torch
+from scipy.stats import norm, kstest
+
+import pytest
+import torchsde
+
+torch.manual_seed(2147483647)
+torch.set_default_dtype(torch.float64)
+
+D = 3
+SMALL_BATCH_SIZE = 16
+LARGE_BATCH_SIZE = 16384
+REPS = 3
+LARGE_REPS = 500
+ALPHA = 0.001
+
+
+devices = [cpu, gpu] = [torch.device('cpu'), torch.device('cuda')]
+
+
+def _setup(device, batch_size):
+    t0, t1 = torch.tensor([0., 1.], device=device)
+    ta = torch.rand([], device=device)
+    tb = torch.rand([], device=device)
+    ta, tb = min(ta, tb), max(ta, tb)
+    bm = torchsde.BrownianInterval(t0=t0, t1=t1, shape=(batch_size, D), dtype=torch.float64, device=device)
+    return ta, tb, bm
+
+
+@pytest.mark.parametrize("device", devices)
+def test_shape(device):
+    if device == gpu and not torch.cuda.is_available():
+        pytest.skip(msg="CUDA not available.")
+
+    ta, tb, bm = _setup(device, SMALL_BATCH_SIZE)
+    sample1 = bm(ta)
+    sample2 = bm(tb)
+    sample3 = bm(ta, tb)
+    assert sample1.shape == sample2.shape == sample3.shape == (SMALL_BATCH_SIZE, D)
+
+    ta, tb, bm = _setup(device, SMALL_BATCH_SIZE)
+    # Query interval before increment
+    sample3 = bm(ta, tb)
+    sample1 = bm(ta)
+    sample2 = bm(tb)
+    assert sample1.shape == sample2.shape == sample3.shape == (SMALL_BATCH_SIZE, D)
+
+
+@pytest.mark.parametrize("device", devices)
+def test_determinism_simple(device):
+    if device == gpu and not torch.cuda.is_available():
+        pytest.skip(msg="CUDA not available.")
+
+    ta, tb, bm = _setup(device, SMALL_BATCH_SIZE)
+    vals = [bm(ta, tb) for _ in range(REPS)]
+    for val in vals[1:]:
+        assert torch.allclose(val, vals[0])
+
+
+@pytest.mark.parametrize("device", devices)
+def test_determinism_large(device):
+    if device == gpu and not torch.cuda.is_available():
+        pytest.skip(msg="CUDA not available.")
+
+    ta, tb, bm = _setup(device, SMALL_BATCH_SIZE)
+    cache = {}
+    for _ in range(LARGE_REPS):
+        ta_ = torch.rand_like(ta)
+        tb_ = torch.rand_like(tb)
+        ta_, tb_ = min(ta_, tb_), max(ta_, tb_)
+        val = bm(ta_, tb_)
+        cache[ta_, tb_] = val.detach().clone()
+
+    cache2 = {}
+    for ta_, tb_ in cache:
+        val = bm(ta_, tb_)
+        cache2[ta_, tb_] = val.detach().clone()
+
+    for ta_, tb_ in cache:
+        assert (cache[ta_, tb_] == cache2[ta_, tb_]).all()
+
+
+@pytest.mark.parametrize("device", devices)
+def test_normality_simple(device):
+    if device == gpu and not torch.cuda.is_available():
+        pytest.skip(msg="CUDA not available.")
+
+    t0_, t1_ = 0.0, 1.0
+    t0, t1 = torch.tensor([t0_, t1_], device=device)
+    eps = 1e-5
+    for _ in range(REPS):
+        W = torch.tensor(npr.randn(), device=device).repeat(LARGE_BATCH_SIZE)
+        bm = torchsde.BrownianInterval(t0=t0, t1=t1, W=W)
+
+        for _ in range(REPS):
+            t_ = npr.uniform(low=t0_ + eps, high=t1_ - eps)
+            samples = bm(t_)
+            samples_ = samples.cpu().detach().numpy()
+
+            mean_ = W.cpu() * (t_ - t0_) / (t1_ - t0_)
+            std_ = np.sqrt((t1_ - t_) * (t_ - t0_) / (t1_ - t0_))
+            ref_dist = norm(loc=mean_, scale=std_)
+
+            _, pval = kstest(samples_, ref_dist.cdf)
+            assert pval >= ALPHA
+
+
+@pytest.mark.parametrize("device", devices)
+@pytest.mark.parametrize("random_order", [False, True])
+def test_continuity(device, random_order):
+    if device == gpu and not torch.cuda.is_available():
+        pytest.skip(msg="CUDA not available.")
+
+    ts = torch.linspace(0., 1., 10000, device=device)
+    bm = torchsde.BrownianInterval(t0=ts[0], t1=ts[-1], shape=(), dtype=ts.dtype, device=device)
+    vals = torch.empty_like(ts)
+    i_ = torch.arange(len(ts), device=device)
+    if random_order:
+        i_ = i_[torch.randperm(len(ts), device=device)]
+    for i in i_:
+        t = ts[i]
+        vals[i] = bm(t)
+    last_val = vals[0]
+    for val in vals[1:]:
+        assert (val - last_val).abs().max() < 5e-2
+        last_val = val
+
+
+@pytest.mark.parametrize("device", devices)
+def test_to_dtype(device):
+    if device == gpu and not torch.cuda.is_available():
+        pytest.skip(msg="CUDA not available.")
+
+    ta, tb, bm = _setup(device, SMALL_BATCH_SIZE)
+    tc = torch.rand_like(ta)
+    td = torch.rand_like(ta)
+    tc, td = min(tc, td), max(tc, td)
+    te = torch.rand_like(ta)
+    tf = torch.rand_like(ta)
+    te, tf = min(te, tf), max(te, tf)
+    tg = torch.rand_like(ta)
+    th = torch.rand_like(ta)
+    tg, th = min(tg, th), max(tg, th)
+
+    w = bm(ta, tb)
+    w2 = bm(tc, td)
+
+    bm.to(torch.float32)
+    w_ = bm(ta, tb)
+    w2_ = bm(tc, td)
+    w3_ = bm(te, tf)
+    w4_ = bm(tg, th)
+
+    bm.to(torch.float64)
+    w3 = bm(te, tf)
+    w4 = bm(tg, th)
+
+    assert w.dtype == w2.dtype == w3.dtype == w4.dtype == torch.float64
+    assert w_.dtype == w2_.dtype == w3_.dtype == w4_.dtype == torch.float32
+    assert torch.allclose(w, w_.double())
+    assert torch.allclose(w2, w2_.double())
+    assert torch.allclose(w3, w3_.double())
+    assert torch.allclose(w4, w4_.double())
+
+
+def test_to_device():
+    if not torch.cuda.is_available():
+        pytest.skip(msg="CUDA not available.")
+
+    ta, tb, bm = _setup(cpu, SMALL_BATCH_SIZE)
+    tc = torch.rand_like(ta)
+    td = torch.rand_like(ta)
+    tc, td = min(tc, td), max(tc, td)
+    te = torch.rand_like(ta)
+    tf = torch.rand_like(ta)
+    te, tf = min(te, tf), max(te, tf)
+    tg = torch.rand_like(ta)
+    th = torch.rand_like(ta)
+    tg, th = min(tg, th), max(tg, th)
+
+    w = bm(ta, tb)
+    w2 = bm(tc, td)
+
+    bm.to(gpu)
+    w_ = bm(ta, tb)
+    w2_ = bm(tc, td)
+    w3_ = bm(te, tf)
+    w4_ = bm(tg, th)
+
+    bm.to(cpu)
+    w3 = bm(te, tf)
+    w4 = bm(tg, th)
+
+    assert str(w.device).startswith('cpu')
+    assert str(w2.device).startswith('cpu')
+    assert str(w3.device).startswith('cpu')
+    assert str(w4.device).startswith('cpu')
+    assert str(w_.device).startswith('cuda')
+    assert str(w2_.device).startswith('cuda')
+    assert str(w3_.device).startswith('cuda')
+    assert str(w4_.device).startswith('cuda')
+    assert torch.allclose(w, w_.cpu())
+    assert torch.allclose(w2, w2_.cpu())
+    assert torch.allclose(w3, w3_.cpu())
+    assert torch.allclose(w4, w4_.cpu())

--- a/tests/test_brownian_path.py
+++ b/tests/test_brownian_path.py
@@ -30,7 +30,7 @@ import itertools
 import torchsde
 import pytest
 
-torch.manual_seed(2147483647)
+torch.manual_seed(1147481649)
 torch.set_default_dtype(torch.float64)
 
 D = 3
@@ -108,12 +108,10 @@ def test_continuity(device, random_order):
     ts = torch.linspace(0., 1., 10000, device=device)
     bm = torchsde.BrownianPath(t0=ts[0], t1=ts[-1], w0=torch.randn((), dtype=ts.dtype, device=device))
     vals = torch.empty_like(ts)
-    i_ = torch.arange(len(ts), device=device)
-    if random_order:
-        i_ = i_[torch.randperm(len(ts), device=device)]
-    for i in i_:
-        t = ts[i]
-        vals[i] = bm(t)
+    t_indices = torch.randperm(len(ts), device=device) if random_order else torch.arange(len(ts), device=device)
+    for t_index in t_indices:
+        t = ts[t_index]
+        vals[t_index] = bm(t)
     last_val = vals[0]
     for val in vals[1:]:
         assert (val - last_val).abs().max() < 5e-2

--- a/tests/test_brownian_path.py
+++ b/tests/test_brownian_path.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the two `BrownianPath`.
+"""Test `BrownianPath`.
 
 The suite tests both running on CPU and CUDA (if available).
 """
@@ -20,7 +20,7 @@ import sys
 
 sys.path = sys.path[1:]  # A hack so that we always import the installed library.
 
-import numpy as np
+import math
 import numpy.random as npr
 import torch
 from scipy.stats import norm, kstest
@@ -43,9 +43,9 @@ devices = [cpu, gpu] = [torch.device('cpu'), torch.device('cuda')]
 
 
 def _setup(brownian_class, device):
-    t0, t1 = torch.tensor([0., 1.]).to(device)
-    w0, w1 = torch.randn([2, BATCH_SIZE, D]).to(device)
-    t = torch.rand([]).to(device)
+    t0, t1 = torch.tensor([0., 1.], device=device)
+    w0, w1 = torch.randn([2, BATCH_SIZE, D], device=device)
+    t = torch.rand([], device=device)
     bm = brownian_class(t0=t0, w0=w0)
     return t, bm
 
@@ -71,28 +71,30 @@ def test_determinism(brownian_class, device):
         assert torch.allclose(val, vals[0])
 
 
-@pytest.mark.parametrize("brownian_class, device", itertools.product(brownian_classes, devices))
+@pytest.mark.parametrize("brownian_class", brownian_classes)
+@pytest.mark.parametrize("device", devices)
 def test_normality(brownian_class, device):
     if device == gpu and not torch.cuda.is_available():
         pytest.skip(msg="CUDA not available.")
 
     t0_, t1_ = 0.0, 1.0
-    t0, t1 = torch.tensor([t0_, t1_]).to(device)
+    t0, t1 = torch.tensor([t0_, t1_], device=device)
     eps = 1e-2
     for _ in range(REPS):
-        w0_, w1_ = 0.0, npr.randn() * np.sqrt(t1_)
-        w0 = torch.tensor(w0_).repeat(BATCH_SIZE).to(device)
-        w1 = torch.tensor(w1_).repeat(BATCH_SIZE).to(device)
+        w0_, w1_ = 0.0, npr.randn() * math.sqrt(t1_)
+        w0 = torch.tensor(w0_, device=device).repeat(BATCH_SIZE)
+        w1 = torch.tensor(w1_, device=device).repeat(BATCH_SIZE)
 
         bm = brownian_class(t0=t0, w0=w0)  # noqa
         bm.insert(t=t1, w=w1)
 
-        t_ = npr.uniform(low=t0_ + eps, high=t1_ - eps)
+        t_ = npr.uniform(low=t0_ + eps, high=t1_ - eps)  # Avoid sampling too close to the boundary.
         samples = bm(t_)
         samples_ = samples.cpu().detach().numpy()
 
+        # True expected mean from Brownian bridge.
         mean_ = ((t1_ - t_) * w0_ + (t_ - t0_) * w1_) / (t1_ - t0_)
-        std_ = np.sqrt((t1_ - t_) * (t_ - t0_) / (t1_ - t0_))
+        std_ = math.sqrt((t1_ - t_) * (t_ - t0_) / (t1_ - t0_))
         ref_dist = norm(loc=mean_, scale=std_)
 
         _, pval = kstest(samples_, ref_dist.cdf)

--- a/tests/test_brownian_tree.py
+++ b/tests/test_brownian_tree.py
@@ -102,7 +102,6 @@ def test_normality(brownian_class, device):
             ref_dist = norm(loc=mean_, scale=std_)
 
             _, pval = kstest(samples_, ref_dist.cdf)
-            print(pval)
             assert pval >= ALPHA
 
 

--- a/tests/test_brownian_tree.py
+++ b/tests/test_brownian_tree.py
@@ -102,6 +102,7 @@ def test_normality(brownian_class, device):
             ref_dist = norm(loc=mean_, scale=std_)
 
             _, pval = kstest(samples_, ref_dist.cdf)
+            print(pval)
             assert pval >= ALPHA
 
 

--- a/tests/test_brownian_tree.py
+++ b/tests/test_brownian_tree.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the two `BrownianTree`.
+"""Test `BrownianTree`.
 
 The suite tests both running on CPU and CUDA (if available).
 """
@@ -43,8 +43,8 @@ devices = [cpu, gpu] = [torch.device('cpu'), torch.device('cuda')]
 
 
 def _setup(brownian_class, device, batch_size):
-    t0, t1 = torch.tensor([0., 1.]).to(device)
-    w0 = torch.zeros(batch_size, D).to(device)
+    t0, t1 = torch.tensor([0., 1.], device=device)
+    w0 = torch.zeros(batch_size, D, device=device)
     t = torch.rand([]).to(device)
     bm = brownian_class(t0=t0, t1=t1, w0=w0, entropy=0)
     return t, bm
@@ -67,7 +67,8 @@ def test_basic(brownian_class, device):
     assert sample.size() == (SMALL_BATCH_SIZE, D)
 
 
-@pytest.mark.parametrize("brownian_class, device", itertools.product(brownian_classes, devices))
+@pytest.mark.parametrize("brownian_class", brownian_classes)
+@pytest.mark.parametrize("device", devices)
 def test_determinism(brownian_class, device):
     if device == gpu and not torch.cuda.is_available():
         pytest.skip(msg="CUDA not available.")
@@ -78,18 +79,19 @@ def test_determinism(brownian_class, device):
         assert torch.allclose(val, vals[0])
 
 
-@pytest.mark.parametrize("brownian_class, device", itertools.product(brownian_classes, devices))
+@pytest.mark.parametrize("brownian_class", brownian_classes)
+@pytest.mark.parametrize("device", devices)
 def test_normality(brownian_class, device):
     if device == gpu and not torch.cuda.is_available():
         pytest.skip(msg="CUDA not available.")
 
     t0_, t1_ = 0.0, 1.0
-    t0, t1 = torch.tensor([t0_, t1_]).to(device)
+    t0, t1 = torch.tensor([t0_, t1_], device=device)
     eps = 1e-5
     for _ in range(REPS):
         w0_, w1_ = 0.0, npr.randn()
-        w0 = torch.tensor(w0_).repeat(LARGE_BATCH_SIZE).to(device)
-        w1 = torch.tensor(w1_).repeat(LARGE_BATCH_SIZE).to(device)
+        w0 = torch.tensor(w0_, device=device).repeat(LARGE_BATCH_SIZE)
+        w1 = torch.tensor(w1_, device=device).repeat(LARGE_BATCH_SIZE)
         bm = brownian_class(t0=t0, t1=t1, w0=w0, w1=w1, pool_size=100, tol=1e-14)  # noqa
 
         for _ in range(REPS):

--- a/tests/test_sdeint.py
+++ b/tests/test_sdeint.py
@@ -24,7 +24,7 @@ from tests import basic_sde
 from tests.torch_test import TorchTestCase
 from torchsde import BrownianPath, sdeint
 
-torch.manual_seed(2147483647)
+torch.manual_seed(1147481649)
 torch.set_default_dtype(torch.float64)
 device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 

--- a/tests/test_sdeint.py
+++ b/tests/test_sdeint.py
@@ -24,7 +24,7 @@ from tests import basic_sde
 from tests.torch_test import TorchTestCase
 from torchsde import BrownianPath, sdeint
 
-torch.manual_seed(0)
+torch.manual_seed(2147483647)
 torch.set_default_dtype(torch.float64)
 device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 

--- a/torchsde/_brownian/brownian_interval.py
+++ b/torchsde/_brownian/brownian_interval.py
@@ -22,11 +22,10 @@ from typing import Optional, Tuple, Union
 import numpy as np
 import torch
 
-from ..settings import LEVY_AREA_APPROXIMATIONS
-from ..types import Scalar
-
 from . import base_brownian
 from . import utils
+from ..settings import LEVY_AREA_APPROXIMATIONS
+from ..types import Scalar
 
 
 _rsqrt3 = 1 / math.sqrt(3)
@@ -54,17 +53,17 @@ class _Interval:
 
     def __init__(self, start, end, parent, is_left, top, generator):
         # These are the things that every interval has
-        self._start = start      # the left hand edge of the interval
-        self._end = end          # the right hand edge of the interval
-        self._parent = parent    # our parent interval
+        self._start = start  # the left hand edge of the interval
+        self._end = end  # the right hand edge of the interval
+        self._parent = parent  # our parent interval
         self._is_left = is_left  # are we the left or right child of our parent
-        self._top = top          # the top-level BrownianInterval, where we cache certain state
+        self._top = top  # the top-level BrownianInterval, where we cache certain state
         self._generator = generator
         self._W_seed, self._H_seed, self._a_seed = generator.generate_state(3)
 
         # These are the things that intervals which are parents also have
-        self._midway = None       # The point at which we split between left and right subintervals
-        self._left_child = None   # The left subinterval
+        self._midway = None  # The point at which we split between left and right subintervals
+        self._left_child = None  # The left subinterval
         self._right_child = None  # The right subinterval
 
     @property
@@ -125,7 +124,7 @@ class _Interval:
             second_coeff = 6 * first_coeff * right_diff * h_reciprocal
 
             left_W = first_coeff * W + second_coeff * H + third_coeff * X1
-            left_H = first_coeff**2 * H - a * X1 + c * right_diff * X2
+            left_H = first_coeff ** 2 * H - a * X1 + c * right_diff * X2
         else:
             # Don't compute space-time Levy area unless we need to
             left_W = self._brownian_bridge(is_left=True)
@@ -140,7 +139,7 @@ class _Interval:
             second_coeff = 6 * first_coeff * left_diff * h_reciprocal
 
             right_W = first_coeff * W - second_coeff * H - third_coeff * X1
-            right_H = first_coeff**2 * H - b * X1 - c * left_diff * X2
+            right_H = first_coeff ** 2 * H - b * X1 - c * left_diff * X2
         else:
             # Don't compute space-time Levy area unless we need to
             right_W = self._brownian_bridge(is_left=False)
@@ -597,9 +596,4 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
                 f")")
 
     def to(self, *args, **kwargs):
-        # TODO: would be nice to actually move across the items in the cache without just deleting them. Would need to
-        #  use a custom LRU cache implementation to do that, though. Maybe use boltons.cacheutils?
-        self.increment_and_space_time_levy_area_cache.cache_clear()
-        self._w_h = tuple(v.to(*args, **kwargs) for v in self._w_h)
-        self.dtype = self._w_h[0].dtype
-        self.device = self._w_h[0].device
+        raise AttributeError(f'BrownianInterval does not support the method "to".')

--- a/torchsde/_brownian/brownian_interval.py
+++ b/torchsde/_brownian/brownian_interval.py
@@ -305,6 +305,7 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
                  device: Optional[Union[str, torch.device]] = None,
                  entropy: Optional[int] = None,
                  dt: Optional[Scalar] = None,
+                 pool_size: int = 8,
                  cache_size: Optional[int] = 45,
                  levy_area_approximation: str = LEVY_AREA_APPROXIMATIONS.none,
                  W: Optional[torch.Tensor] = None,
@@ -326,6 +327,9 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
                 to equal the first step this is evaluated with. This allows us
                 to set up a structure that should be efficient to query at these
                 intervals.
+            pool_size (int): Size of the pooled entropy. If you care about
+                statistical randomness then increasing this will help (but will
+                slow things down).
             cache_size: How big a cache of recent calculations to use. (As new
                 calculations depend on old calculations, this speeds things up
                 dramatically, rather than recomputing things.) The default is
@@ -412,7 +416,7 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
 
         self.increment_and_space_time_levy_area_cache = increment_and_space_time_levy_area_cache
 
-        generator = np.random.SeedSequence(entropy=entropy)
+        generator = np.random.SeedSequence(entropy=entropy, pool_size=pool_size)
         # First three states are reserved as in _Initial
         _, _, _, initial_W_seed, initial_H_seed = generator.generate_state(5)
 

--- a/torchsde/_brownian/brownian_interval.py
+++ b/torchsde/_brownian/brownian_interval.py
@@ -379,8 +379,7 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
             dtypes.append(dtype)
         if device is None:
             if len(devices) == 0:
-                # Is there no better way to get the current default device?
-                devices.append(torch.empty(()).device)
+                devices.append(torch.device('cpu'))
         else:
             devices.append(torch.device(device))
         if len(shapes) == 0:

--- a/torchsde/_brownian/brownian_tree.py
+++ b/torchsde/_brownian/brownian_tree.py
@@ -14,6 +14,7 @@
 
 import copy
 import math
+import warnings
 from typing import Optional
 
 import blist
@@ -165,10 +166,12 @@ class BrownianTree(base_brownian.BaseBrownian):
 
     def call(self, t):
         t = float(t)
-        if t <= self._t0:
-            return utils.search_and_insert(ts=self._ts_prev, ws=self._ws_prev, t=t)
-        if t >= self._t1:
-            return utils.search_and_insert(ts=self._ts_post, ws=self._ws_post, t=t)
+        if t < self._t0:
+            warnings.warn(f"Should have t>=t0 but got t={t} and t0={self._t0}.")
+            t = self._t0
+        if t > self._t1:
+            warnings.warn(f"Should have t<=t1 but got t={t} and t1={self._t1}.")
+            t = self._t1
 
         # TODO: Replace with `torch.searchsorted` when torch==1.7.0 releases.
         #  Also need to make sure we use tensor dt.

--- a/torchsde/_brownian/utils.py
+++ b/torchsde/_brownian/utils.py
@@ -112,6 +112,9 @@ def space_time_levy_area(W, h, levy_area_approximation, get_noise):
         return None
 
 
+_r12 = 1 / 12
+
+
 def davie_foster_approximation(W, H, h, levy_area_approximation, get_noise):
     if levy_area_approximation in (LEVY_AREA_APPROXIMATIONS.none, LEVY_AREA_APPROXIMATIONS.space_time):
         return None
@@ -120,14 +123,15 @@ def davie_foster_approximation(W, H, h, levy_area_approximation, get_noise):
     else:
         # Davie's approximation to the Levy area from space-time Levy area
         A = H.unsqueeze(-1) * W.unsqueeze(-2) - W.unsqueeze(-1) * H.unsqueeze(-2)
+        noise = get_noise()
+        noise = noise - noise.transpose(-1, -2)  # noise is skew symmetric of variance 2
         if levy_area_approximation == LEVY_AREA_APPROXIMATIONS.foster:
             # Foster's additional correction to Davie's approximation
             tenth_h = 0.1 * h
             H_squared = H ** 2
             var = tenth_h * (tenth_h + H_squared.unsqueeze(-1) + H_squared.unsqueeze(-2))
-            noise = get_noise()
-            noise = noise - noise.transpose(-1, -2)
-            # noise is skew symmetric of variance 2
-            a_tilde = math.sqrt(var) * noise
-            A += a_tilde
+        else:  # davie approximation
+            var = _r12 * h ** 2
+        a_tilde = math.sqrt(var) * noise
+        A += a_tilde
         return A

--- a/torchsde/_brownian/utils.py
+++ b/torchsde/_brownian/utils.py
@@ -118,7 +118,9 @@ _r12 = 1 / 12
 def davie_foster_approximation(W, H, h, levy_area_approximation, get_noise):
     if levy_area_approximation in (LEVY_AREA_APPROXIMATIONS.none, LEVY_AREA_APPROXIMATIONS.space_time):
         return None
-    elif W.shape == ():
+    elif W.ndimension() in (0, 1):
+        # If we have zero or one dimensions then treat the scalar / single dimension we have as batch, so that the
+        # Brownian motion is one dimensional and the Levy area is zero.
         return torch.zeros_like(W)
     else:
         # Davie's approximation to the Levy area from space-time Levy area
@@ -129,9 +131,9 @@ def davie_foster_approximation(W, H, h, levy_area_approximation, get_noise):
             # Foster's additional correction to Davie's approximation
             tenth_h = 0.1 * h
             H_squared = H ** 2
-            var = tenth_h * (tenth_h + H_squared.unsqueeze(-1) + H_squared.unsqueeze(-2))
+            std = (tenth_h * (tenth_h + H_squared.unsqueeze(-1) + H_squared.unsqueeze(-2))).sqrt()
         else:  # davie approximation
-            var = _r12 * h ** 2
-        a_tilde = math.sqrt(var) * noise
+            std = math.sqrt(_r12 * h ** 2)
+        a_tilde = std * noise
         A += a_tilde
         return A

--- a/torchsde/brownian_lib/brownian_tree.py
+++ b/torchsde/brownian_lib/brownian_tree.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import random
+import warnings
 from typing import Optional
 
 import torch
@@ -128,6 +129,12 @@ class BrownianTree(base_brownian.BaseBrownian):
                 return W
 
     def call(self, t):
+        if t < self._t0:
+            warnings.warn(f"Should have t>=t0 but got t={t} and t0={self._t0}.")
+            t = self._t0
+        if t > self._t1:
+            warnings.warn(f"Should have t<=t1 but got t={t} and t1={self._t1}.")
+            t = self._t1
         return self._bm(t)
 
     def __repr__(self):


### PR DESCRIPTION
Many things on `BrownianInterval`:
- Added tests!
- Fixed various bugs (#25)
- Sped things up slightly
- dtype/device now optional arguments (#26)
- Fixed getting RecursionErrors with very large cache sizes

Fixed behaviour for calling `BrownianInterval` and `BrownianTree` for `t` outside of their range (it now clamps and raises a warning) (#9, #10)

Fixed bug that prevented `ForwardSDE.g_prod` from being called. Tided it slightly.

Fixed SDE solvers stepping outside the region of integration.

Btw @lxuechen I don't actually follow what you were saying about there being a bug in `ReverseBrownian`?