### PR TITLE
Binterval recursion fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
                        optional=True)
     ],
     cmdclass={'build_ext': cpp_extension.BuildExtension},
-    install_requires=['torch>=1.6.0', 'blist', 'numpy>=1.19.1', 'boltons'],
+    install_requires=['torch>=1.6.0', 'blist', 'numpy>=1.19.1', 'boltons>=20.2.1'],
     python_requires='~=3.6',
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
                        optional=True)
     ],
     cmdclass={'build_ext': cpp_extension.BuildExtension},
-    install_requires=['torch>=1.6.0', 'blist', 'numpy>=1.19.1'],
+    install_requires=['torch>=1.6.0', 'blist', 'numpy>=1.19.1', 'boltons'],
     python_requires='~=3.6',
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Rather than trampolining everything, I've taken the more straightforward approach of inlining a lot of the function indirections that were previously present. This should reduce the size of the call stack that's built up by a factor of something like six.

The code is largely cleaner for this change, as well, which is nice.

It does introduce one additional dependency: [boltons](https://boltons.readthedocs.io/en/latest/), which is a popular stdlib-like library for "things that are missing from the stdlib"; in this case a better LRU cache implementation. Obviously additional dependencies are to be avoided, but I think this one is reasonable.