### PR TITLE
BInterval - U fix

### DIFF
--- a/tests/test_brownian_interval.py
+++ b/tests/test_brownian_interval.py
@@ -29,7 +29,7 @@ import pytest
 import torchsde
 from torchsde._brownian import utils
 
-torch.manual_seed(1147481648)
+torch.manual_seed(1147481649)
 torch.set_default_dtype(torch.float64)
 
 D = 3

--- a/tests/test_brownian_interval.py
+++ b/tests/test_brownian_interval.py
@@ -23,10 +23,11 @@ sys.path = sys.path[1:]  # A hack so that we always import the installed library
 import math
 import numpy.random as npr
 import torch
-from scipy.stats import norm, kstest
+from scipy.stats import kstest
 
 import pytest
 import torchsde
+from torchsde._brownian import utils
 
 torch.manual_seed(1147481648)
 torch.set_default_dtype(torch.float64)
@@ -37,7 +38,7 @@ LARGE_BATCH_SIZE = 131072
 REPS = 3
 MEDIUM_REPS = 25
 LARGE_REPS = 500
-ALPHA = 0.001
+ALPHA = 0.0001
 POOL_SIZE = 32
 
 devices = [cpu, gpu] = [torch.device('cpu'), torch.device('cuda')]
@@ -166,19 +167,30 @@ def test_normality_simple(device, levy_area_approximation):
 
     t0, t1 = 0.0, 1.0
     for _ in range(REPS):
-        W = torch.tensor(npr.randn(), device=device).repeat(LARGE_BATCH_SIZE)
-        bm = torchsde.BrownianInterval(t0=t0, t1=t1, W=W, levy_area_approximation=levy_area_approximation)
+        base_W = torch.tensor(npr.randn(), device=device).repeat(LARGE_BATCH_SIZE)
+        bm = torchsde.BrownianInterval(t0=t0, t1=t1, W=base_W, levy_area_approximation=levy_area_approximation)
 
         t_ = npr.uniform(low=t0, high=t1)
-        samples = bm(t_)
-        samples_ = samples.cpu().detach().numpy()
 
-        mean_ = W.cpu() * (t_ - t0) / (t1 - t0)
-        std_ = math.sqrt((t1 - t_) * (t_ - t0) / (t1 - t0))
-        ref_dist = norm(loc=mean_, scale=std_)
+        W = bm(t0, t_)
 
-        _, pval = kstest(samples_, ref_dist.cdf)
+        mean_W = base_W * (t_ - t0) / (t1 - t0)
+        std_W = math.sqrt((t1 - t_) * (t_ - t0) / (t1 - t0))
+        rescaled_W = (W - mean_W) / std_W
+
+        _, pval = kstest(rescaled_W.cpu().detach().numpy(), 'norm')
         assert pval >= ALPHA
+
+        if levy_area_approximation != 'none':
+            W, U = bm(t0, t_, return_U=True)
+            H = utils.U_to_H(W, U, t_ - t0)
+
+            mean_H = 0
+            std_H = math.sqrt((t_ - t0) / 12)
+            rescaled_H = (H - mean_H) / std_H
+
+            _, pval = kstest(rescaled_H.cpu().detach().numpy(), 'norm')
+            assert pval >= ALPHA
 
 
 @pytest.mark.parametrize("device", devices)
@@ -198,16 +210,53 @@ def test_normality_conditional(device, levy_area_approximation):
             tb = npr.uniform(low=t0, high=t1)
             ta, t_, tb = sorted([t_, ta, tb])
 
-            increment = bm(ta, tb).cpu().detach().numpy()
-            sample = bm(ta, t_).cpu().detach().numpy()
+            W = bm(ta, tb)
+            W1 = bm(ta, t_)
+            W2 = bm(t_, tb)
 
-            mean = increment * (t_ - ta) / (tb - ta)
-            std = math.sqrt((tb - t_) * (t_ - ta) / (tb - ta))
-            rescaled_sample = (sample - mean) / std
-
-            _, pval = kstest(rescaled_sample, 'norm')
-
+            mean_W1 = W * (t_ - ta) / (tb - ta)
+            std_W1 = math.sqrt((tb - t_) * (t_ - ta) / (tb - ta))
+            rescaled_W1 = (W1 - mean_W1) / std_W1
+            _, pval = kstest(rescaled_W1.cpu().detach().numpy(), 'norm')
             assert pval >= ALPHA
+
+            mean_W2 = W * (tb - t_) / (tb - ta)
+            std_W2 = math.sqrt((tb - t_) * (t_ - ta) / (tb - ta))
+            rescaled_W2 = (W2 - mean_W2) / std_W2
+            _, pval = kstest(rescaled_W2.cpu().detach().numpy(), 'norm')
+            assert pval >= ALPHA
+
+            if levy_area_approximation != 'none':
+                W, U = bm(ta, tb, return_U=True)
+                W1, U1 = bm(ta, t_, return_U=True)
+                W2, U2 = bm(t_, tb, return_U=True)
+
+                h = tb - ta
+                h1 = t_ - ta
+                h2 = tb - t_
+
+                denom = math.sqrt(h1 ** 3 + h2 ** 3)
+                a = h1 ** 3.5 * h2 ** 0.5 / (2 * h * denom)
+                b = h1 ** 0.5 * h2 ** 3.5 / (2 * h * denom)
+                c = math.sqrt(3) * h1 ** 1.5 * h2 ** 1.5 / (6 * denom)
+
+                H = utils.U_to_H(W, U, h)
+                H1 = utils.U_to_H(W1, U1, h1)
+                H2 = utils.U_to_H(W2, U2, h2)
+
+                mean_H1 = H * (h1 / h) ** 2
+                std_H1 = math.sqrt(a**2 + c**2) / h1
+                rescaled_H1 = (H1 - mean_H1) / std_H1
+
+                _, pval = kstest(rescaled_H1.cpu().detach().numpy(), 'norm')
+                assert pval >= ALPHA
+
+                mean_H2 = H * (h2 / h) ** 2
+                std_H2 = math.sqrt(b**2 + c**2) / h2
+                rescaled_H2 = (H2 - mean_H2) / std_H2
+
+                _, pval = kstest(rescaled_H2.cpu().detach().numpy(), 'norm')
+                assert pval >= ALPHA
 
 
 @pytest.mark.parametrize("device", devices)
@@ -232,24 +281,13 @@ def test_consistency(device, levy_area_approximation):
                 W = bm(ta, tb)
                 W1 = bm(ta, t_)
                 W2 = bm(t_, tb)
-            elif levy_area_approximation == 'space-time':
+            else:
                 W, U = bm(ta, tb, return_U=True)
                 W1, U1 = bm(ta, t_, return_U=True)
                 W2, U2 = bm(t_, tb, return_U=True)
-            else:
-                W, A = bm(ta, tb, return_A=True)
-                W1, A1 = bm(ta, t_, return_A=True)
-                W2, A2 = bm(t_, tb, return_A=True)
 
             torch.testing.assert_allclose(W1 + W2, W, rtol=1e-6, atol=1e-6)
-            if levy_area_approximation == 'space-time':
+            if levy_area_approximation != 'none':
                 torch.testing.assert_allclose(U1 + U2 + (tb - t_) * W1, U, rtol=1e-6, atol=1e-6)
-            if levy_area_approximation in ('davie', 'foster'):
-                W11, W12 = W1.unbind(dim=1)
-                W21, W22 = W2.unbind(dim=1)
-                correction = torch.empty((LARGE_BATCH_SIZE, 2, 2), dtype=A.dtype, device=A.device)
-                correction[..., 0, 0] = 0
-                correction[..., 1, 1] = 0
-                correction[..., 0, 1] = 0.5 * (W11 * W22 - W12 * W21)
-                correction[..., 1, 0] = 0.5 * (W12 * W21 - W11 * W22)
-                torch.testing.assert_allclose(A1 + A2 + correction, A, rtol=1e-6, atol=1e-6)
+
+            # We don't test the return_A case because we don't expect that to be consistent.

--- a/tests/test_brownian_interval.py
+++ b/tests/test_brownian_interval.py
@@ -205,10 +205,7 @@ def test_normality_conditional(device, levy_area_approximation):
                                        levy_area_approximation=levy_area_approximation, pool_size=POOL_SIZE)
 
         for _ in range(MEDIUM_REPS):
-            t_ = npr.uniform(low=t0, high=t1)
-            ta = npr.uniform(low=t0, high=t1)
-            tb = npr.uniform(low=t0, high=t1)
-            ta, t_, tb = sorted([t_, ta, tb])
+            ta, t_, tb = sorted(npr.uniform(low=t0, high=t1, size=(3,)))
 
             W = bm(ta, tb)
             W1 = bm(ta, t_)
@@ -267,15 +264,12 @@ def test_consistency(device, levy_area_approximation):
 
     t0, t1 = 0.0, 1.0
     for _ in range(REPS):
-        bm = torchsde.BrownianInterval(t0=t0, t1=t1, shape=(LARGE_BATCH_SIZE, 2),  # 2 to have nontrivial Levy area
+        bm = torchsde.BrownianInterval(t0=t0, t1=t1, shape=(LARGE_BATCH_SIZE,),
                                        device=device,
                                        levy_area_approximation=levy_area_approximation, pool_size=POOL_SIZE)
 
         for _ in range(MEDIUM_REPS):
-            t_ = npr.uniform(low=t0, high=t1)
-            ta = npr.uniform(low=t0, high=t1)
-            tb = npr.uniform(low=t0, high=t1)
-            ta, t_, tb = sorted([t_, ta, tb])
+            ta, t_, tb = sorted(npr.uniform(low=t0, high=t1, size=(3,)))
 
             if levy_area_approximation == 'none':
                 W = bm(ta, tb)

--- a/torchsde/_brownian/brownian_interval.py
+++ b/torchsde/_brownian/brownian_interval.py
@@ -540,11 +540,11 @@ class BrownianInterval(_Interval, base_brownian.BaseBrownian):
                 f"t1={self._end:.3f}, "
                 f"shape={self.shape}, "
                 f"dtype={self.dtype}, "
-                f"device={self.device}, "
+                f"device={repr(self.device)}, "
                 f"entropy={self._entropy}, "
                 f"dt={dt}, "
                 f"cache_size={self._cache_size}, "
-                f"levy_area_approximation={self.levy_area_approximation}"
+                f"levy_area_approximation={repr(self.levy_area_approximation)}"
                 f")")
 
     def to(self, *args, **kwargs):

--- a/torchsde/_brownian/utils.py
+++ b/torchsde/_brownian/utils.py
@@ -25,15 +25,6 @@ _rsqrt3 = 1 / math.sqrt(3)
 _r12 = 1 / 12
 
 
-class BrownianReturn:
-    __slots__ = ('W', 'U', 'A')
-
-    def __init__(self, W, U=None, A=None):
-        self.W = W
-        self.U = U
-        self.A = A
-
-
 def randn_like(ref: torch.Tensor, seed: Optional[int] = None) -> torch.Tensor:
     if seed is None:
         return torch.randn_like(ref)


### PR DESCRIPTION
- Fixed the `U` returned from BInterval.
- Added tests for `U`.
- Added repetitions back to `test_brownian_interval.py::test_normality_conditional`.

I've ran all the tests and all the diagnostics and everything LGTM. Sorry this took so long, getting the tests working proved surprisingly finickity.

I've not added any tests for `A`, basically because I don't see any sensible options for doing so.
We can't check consistency, i.e. is
```
\int_s^t W^1_{s,u} dW^2_u = \int_s^v W^1_{s,u} dW^2_u + \int_v^t W^1_{s,v} dW^2_u + \int_v^t W^1_{v,u} dW^2_u
```
true [or rather the antisymmetric version of this] because we're not trying to satisfy this condition anyway. Davie-Foster corrections are generated on each subinterval independently. Moreover it's not clear that generating one on one subinterval, and then calculating the other, will produce the correct behaviour on the second subinterval, as these are only approximations.

We can't check for distribution, because the distribution of `A` is unknown.

We _could_ independently implement the calculation we're already doing, and see if both approximations match. Worth doing do you think?