### PR TITLE
Bugfixes for log-ODE

### DIFF
--- a/diagnostics/inspection.py
+++ b/diagnostics/inspection.py
@@ -85,7 +85,7 @@ def inspect_orders(y0: Tensor,
 
     sde = copy.deepcopy(sde).requires_grad_(False)
     ts = torch.tensor([t0, t1], device=y0.device)
-    
+
     solns = [
         [sdeint(sde, y0, ts, bm, method=method, dt=dt, options=options_)[-1]
          for method, options_ in zip(methods, options)]
@@ -101,7 +101,7 @@ def inspect_orders(y0: Tensor,
         mses_for_dt = [utils.mse(soln, true) for soln in solns_]
         mses.append(mses_for_dt)
 
-        maes_for_dt = [utils.mae(soln, true, test_func) for soln in solns]
+        maes_for_dt = [utils.mae(soln, true, test_func) for soln in solns_]
         maes.append(maes_for_dt)
 
     strong_order_slopes = [

--- a/diagnostics/ito_additive.py
+++ b/diagnostics/ito_additive.py
@@ -25,7 +25,7 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d, m = 16, 8192, 3, 5
-    t0, t1, steps, dt = 0., 1., 10, 1e-1
+    t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = AdditiveSDE(d=d, m=m).to(device)

--- a/diagnostics/ito_additive.py
+++ b/diagnostics/ito_additive.py
@@ -25,9 +25,9 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d, m = 16, 8192, 3, 5
-    t0, t1, steps, dt = 0., 2., 10, 1e-1
+    t0, t1, steps, dt = 0., 1., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
-    dts = tuple(2 ** -i for i in range(1, 8))  # For checking strong order.
+    dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = AdditiveSDE(d=d, m=m).to(device)
     methods = ('euler', 'srk')
     img_dir = os.path.join(os.path.dirname(__file__), 'plots', 'ito_additive')

--- a/diagnostics/ito_diagonal.py
+++ b/diagnostics/ito_diagonal.py
@@ -25,9 +25,9 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d = 16, 8192, 5
-    t0, t1, steps, dt = 0., 2., 10, 1e-1
+    t0, t1, steps, dt = 0., 1., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
-    dts = tuple(2 ** -i for i in range(1, 8))  # For checking strong order.
+    dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex2(d=d).to(device)
 
     methods = ('euler', 'srk', 'milstein', 'milstein')

--- a/diagnostics/ito_diagonal.py
+++ b/diagnostics/ito_diagonal.py
@@ -25,7 +25,7 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d = 16, 8192, 5
-    t0, t1, steps, dt = 0., 1., 10, 1e-1
+    t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex2(d=d).to(device)

--- a/diagnostics/ito_scalar.py
+++ b/diagnostics/ito_scalar.py
@@ -25,7 +25,7 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d = 16, 8192, 10
-    t0, t1, steps, dt = 0., 1., 10, 1e-1
+    t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex2Scalar(d=d).to(device)

--- a/diagnostics/ito_scalar.py
+++ b/diagnostics/ito_scalar.py
@@ -25,9 +25,9 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d = 16, 8192, 10
-    t0, t1, steps, dt = 0., 2., 10, 1e-1
+    t0, t1, steps, dt = 0., 1., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
-    dts = tuple(2 ** -i for i in range(1, 8))  # For checking strong order.
+    dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex2Scalar(d=d).to(device)
 
     methods = ('euler', 'srk', 'milstein')

--- a/diagnostics/stratonovich_additive.py
+++ b/diagnostics/stratonovich_additive.py
@@ -25,9 +25,9 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d, m = 16, 8192, 3, 5
-    t0, t1, steps, dt = 0., 2., 10, 1e-1
+    t0, t1, steps, dt = 0., 1., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
-    dts = tuple(2 ** -i for i in range(1, 8))  # For checking strong order.
+    dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = AdditiveSDE(d=d, m=m, sde_type=SDE_TYPES.stratonovich).to(device)
     # Don't test Milstein methods, since there's no advantage to use extra resource to compute 0s.
     methods = ('heun', 'euler_heun', 'midpoint')

--- a/diagnostics/stratonovich_additive.py
+++ b/diagnostics/stratonovich_additive.py
@@ -25,7 +25,7 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d, m = 16, 8192, 3, 5
-    t0, t1, steps, dt = 0., 1., 10, 1e-1
+    t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = AdditiveSDE(d=d, m=m, sde_type=SDE_TYPES.stratonovich).to(device)

--- a/diagnostics/stratonovich_diagonal.py
+++ b/diagnostics/stratonovich_diagonal.py
@@ -25,7 +25,7 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d = 16, 8192, 3
-    t0, t1, steps, dt = 0., 1., 10, 1e-1
+    t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex1(d=d, sde_type=SDE_TYPES.stratonovich).to(device)

--- a/diagnostics/stratonovich_diagonal.py
+++ b/diagnostics/stratonovich_diagonal.py
@@ -25,9 +25,9 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d = 16, 8192, 3
-    t0, t1, steps, dt = 0., 2., 10, 1e-1
+    t0, t1, steps, dt = 0., 1., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
-    dts = tuple(2 ** -i for i in range(1, 8))  # For checking strong order.
+    dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex1(d=d, sde_type=SDE_TYPES.stratonovich).to(device)
     methods = ('heun', 'euler_heun', 'midpoint', 'milstein', 'milstein')
     options = (None, None, None, None, dict(grad_free=True))

--- a/diagnostics/stratonovich_general.py
+++ b/diagnostics/stratonovich_general.py
@@ -25,7 +25,7 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d, m = 16, 8192, 3, 5
-    t0, t1, steps, dt = 0., 1., 10, 1e-1
+    t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex4(d=d, m=m, sde_type=SDE_TYPES.stratonovich).to(device)

--- a/diagnostics/stratonovich_general.py
+++ b/diagnostics/stratonovich_general.py
@@ -25,9 +25,9 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d, m = 16, 8192, 3, 5
-    t0, t1, steps, dt = 0., 2., 10, 1e-1
+    t0, t1, steps, dt = 0., 1., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
-    dts = tuple(2 ** -i for i in range(1, 8))  # For checking strong order.
+    dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex4(d=d, m=m, sde_type=SDE_TYPES.stratonovich).to(device)
     methods = ('midpoint', 'log_ode')
     img_dir = os.path.join(os.path.dirname(__file__), 'plots', 'stratonovich_general')

--- a/diagnostics/stratonovich_scalar.py
+++ b/diagnostics/stratonovich_scalar.py
@@ -25,9 +25,9 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d, m = 16, 8192, 3, 5
-    t0, t1, steps, dt = 0., 2., 10, 1e-1
+    t0, t1, steps, dt = 0., 1., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
-    dts = tuple(2 ** -i for i in range(1, 8))  # For checking strong order.
+    dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex1Scalar(d=d, sde_type=SDE_TYPES.stratonovich).to(device)
     methods = ('heun', 'euler_heun', 'midpoint', 'milstein', 'milstein')
     options = (None, None, None, None, dict(grad_free=True))

--- a/diagnostics/stratonovich_scalar.py
+++ b/diagnostics/stratonovich_scalar.py
@@ -25,7 +25,7 @@ from . import utils
 
 def main():
     small_batch_size, large_batch_size, d, m = 16, 8192, 3, 5
-    t0, t1, steps, dt = 0., 1., 10, 1e-1
+    t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
     sde = Ex1Scalar(d=d, sde_type=SDE_TYPES.stratonovich).to(device)

--- a/tests/test_strat.py
+++ b/tests/test_strat.py
@@ -23,6 +23,7 @@ import torch
 
 from torchsde import sdeint_adjoint, BrownianInterval
 from torchsde._core.base_sde import ForwardSDE  # noqa
+from torchsde.settings import SDE_TYPES
 from .problems import Ex4
 
 torch.manual_seed(1147481649)
@@ -101,7 +102,7 @@ def check_efficiency():
 
 
 def test_adjoint():
-    sde = Ex4(d=d, m=m).to(device)
+    sde = Ex4(d=d, m=m, sde_type=SDE_TYPES.stratonovich).to(device)
     bm = BrownianInterval(t0=t0, t1=t1, shape=(batch_size, m), dtype=dtype, device=device)
 
     def func(y0):

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -180,6 +180,8 @@ def check_contract(sde, y0, ts, bm, method, names):
     if bm is None:
         if method == METHODS.srk:
             levy_area_approximation = LEVY_AREA_APPROXIMATIONS.space_time
+        elif method == METHODS.log_ode_midpoint:
+            levy_area_approximation = LEVY_AREA_APPROXIMATIONS.foster
         else:
             levy_area_approximation = LEVY_AREA_APPROXIMATIONS.none
         bm = BrownianInterval(t0=ts[0], t1=ts[-1], shape=(*batch_dimensions, noise_channels), dtype=y0.dtype,

--- a/torchsde/settings.py
+++ b/torchsde/settings.py
@@ -50,7 +50,7 @@ class SDE_TYPES(metaclass=ContainerMeta):  # noqa
 
 class LEVY_AREA_APPROXIMATIONS(metaclass=ContainerMeta):  # noqa
     none = 'none'  # Don't compute any Levy area approximation
-    space_time = 'space-time'  # Only compute an (exact) space-time Levy area
+    space_time = 'space_time'  # Only compute an (exact) space-time Levy area
     davie = 'davie'  # Compute Davie's approximation to Levy area
     foster = 'foster'  # Compute Foster's correction to Davie's approximation to Levy area
 


### PR DESCRIPTION
Note that I'm looking to merge this into `dev-log-ode`.

- I noted that the diagnostics didn't run in #43, due to a RecursionError in BInterval. The reason is that the access patterns are a bad fit for what BInterval is optimised for. I've fixed this here by reordering the calls in `inspect_strong_order`.*
- I've also increased the smallest step size in the diagnostics from 2**-8 to 2**-7, as I started to observe the rates misbehaving for small values, presumably because they were approaching the "analytical" discretisation.
- I've also fixed a bug introduced in #43 that prevented `test_strat.py` from running. (The SDE was set to Ito.)
- Fixed a bug that prevented log-ODE from using the default-created BrownianInterval because it didn't have the right `levy_area_approximation` set.

*The RecursionErrors here are a good indication that trampolining / tail recursion is probably worth adding to BInterval. I'll probably focus on other things(=running experiments for the paper) in the short term, but I'll aim to get that added in time for our next release.