### PR TITLE
Add adjoint support for general/scalar noise in the Ito case.

### DIFF
--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -54,9 +54,6 @@ def test_adjoint(problem, method, sde_type, noise_type, adaptive):
         return
     if sde_type == 'ito' and noise_type == 'general':
         return
-    # TODO: fix this.
-    if noise_type == 'scalar':
-        pytest.xfail("Ito SDE w/ scalar noise for adjoint doesn't work yet.")
 
     d = 1 if noise_type == 'scalar' else 10
     batch_size = 128

--- a/torchsde/_core/adjoint.py
+++ b/torchsde/_core/adjoint.py
@@ -169,10 +169,12 @@ def sdeint_adjoint(sde: nn.Module,
             or `sde` is missing required methods.
 
     Note:
-        Double-backward is supported, and will use the adjoint method to compute the gradient of the adjoint. (i.e.
-        rather than backpropagating through the numerical solver used for the adjoint.) The same `adjoint_method`,
-        `adjoint_adaptive`, `adjoint_rtol, `adjoint_atol`, `adjoint_options` will be used for the second-order adjoint
-        as is used for the first-order adjoint.
+        Double-backward is supported, and will use the adjoint method to compute
+        the gradient of the adjoint. (i.e. rather than backpropagating through
+        the numerical solver used for the adjoint.) The same `adjoint_method`,
+        `adjoint_adaptive`, `adjoint_rtol, `adjoint_atol`, `adjoint_options`
+        will be used for the second-order adjoint as is used for the first-order
+        adjoint.
     """
     misc.handle_unused_kwargs(unused_kwargs, msg="`sdeint_adjoint`")
     del unused_kwargs


### PR DESCRIPTION
So the primary reason that the scalar noise tests failed was that the corrected drift wasn't implemented. Just implemented it now and all tests are passing.  

I also wrapped the note about double backward in the docstring to be capped at 80, so that it's easier to read, say, when `help` is called in an interactive session. 

