### PR TITLE
Automates torch installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,21 @@
 
 import os
 import platform
-
+import warnings
 import setuptools
+import subprocess
+import sys
+from importlib import reload
 
 try:
     import torch
     from torch.utils import cpp_extension
 except ModuleNotFoundError:
-    raise ModuleNotFoundError("Unable to import torch. Please install torch>=1.6.0 at https://pytorch.org.")
+    warnings.warn(ModuleNotFoundError("Unable to import torch. Installing torch>=1.6.0"))
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "torch==1.6.0"])
+
+    import torch
+    from torch.utils import cpp_extension
 
 extra_compile_args = []
 extra_link_args = []


### PR DESCRIPTION
Currently, having torchsde as a dependency creates problem while installing in isolated environments.
The problem is when installing a repo, it collects all the dependencies before it installs them. TorchSDE while being collected checks for torch. This creates problems in isolated envs as torch would not be there by default.

In this PR, I have removed the raising of the exception with a warning and have dynamically installed torch at runtime.
This should solve the build problems.