### PR TITLE
Add fail-fast: false

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,6 +60,7 @@ jobs:
       matrix:
         python-version: [ 3.6, 3.8 ]
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
+      fail-fast: false
     needs: [ check_version ]
     steps:
       - name: Checkout code


### PR DESCRIPTION
Set the tests not to cancel if one of them fails.

Unrelatedly, do you want to make passing the tests a requirement to merge?
Settings->Branches->Branch protection rule.
Can also use this to require reviews before merging.
Leaving "include administrators" unticked will allow (just) you to merge even if the tests fail by clicking through a "I know what I'm doing" warning.