### PR TITLE
Dev methods fixes

### DIFF
--- a/tests/basic_sde.py
+++ b/tests/basic_sde.py
@@ -158,33 +158,6 @@ class ScalarSDE(AdditiveSDE):
         super(ScalarSDE, self).__init__(d=d, m=1, sde_type=sde_type)
 
 
-class TupleSDE(SDEIto):
-    def __init__(self, d=10):
-        super(TupleSDE, self).__init__(noise_type="diagonal")
-        self.shared_param = nn.Parameter(torch.randn(1, d), requires_grad=True)
-        self.no_grad_param = nn.Parameter(torch.randn(1, d), requires_grad=False)
-        self.unused_param1 = nn.Parameter(torch.randn(1, d), requires_grad=False)
-        self.unused_param2 = nn.Parameter(torch.randn(1, d), requires_grad=True)
-
-    def f(self, t, y):
-        y, = y
-        return (
-            self.shared_param * torch.sin(y) * 0.2 +
-            torch.sin(y ** 2.) * 0.1 +
-            torch.cos(t) +
-            self.no_grad_param * y,
-        )
-
-    def g(self, t, y):
-        y, = y
-        return torch.sigmoid(
-            self.shared_param * torch.cos(y) * .3 + torch.sin(t)) + torch.sigmoid(self.no_grad_param * y),
-
-    def h(self, t, y):
-        y, = y
-        return torch.sigmoid(y),
-
-
 class CustomNamesSDE(SDEIto):
     def __init__(self):
         super(CustomNamesSDE, self).__init__(noise_type="diagonal")

--- a/tests/basic_sde.py
+++ b/tests/basic_sde.py
@@ -94,9 +94,12 @@ class BasicSDE4(SDEIto):
         return torch.sigmoid(y)
 
 
-class GeneralSDE(SDEIto):
-    def __init__(self, d=10, m=3):
-        super(GeneralSDE, self).__init__(noise_type="general")
+class GeneralSDE(torch.nn.Module):
+    noise_type = 'general'
+
+    def __init__(self, d=10, m=3, sde_type=SDE_TYPES.ito):
+        super(GeneralSDE, self).__init__()
+        self.sde_type = sde_type
         self.shared_param = nn.Parameter(torch.randn(1, d), requires_grad=True)
         self.no_grad_param = nn.Parameter(torch.randn(1, d, m), requires_grad=False)
         self.unused_param1 = nn.Parameter(torch.randn(1, d), requires_grad=False)
@@ -112,9 +115,29 @@ class GeneralSDE(SDEIto):
         return torch.sigmoid(y)
 
 
-class AdditiveSDE(BaseSDE):
+class DiagonalSDE(torch.nn.Module):
+    noise_type = 'diagonal'
+
+    def __init__(self, sde_type=SDE_TYPES.ito):
+        super(DiagonalSDE, self).__init__()
+        self.sde_type = sde_type
+
+    def f(self, t, y):
+        return y.cos()
+
+    def g(self, t, y):
+        return y.sin()
+
+    def h(self, t, y):
+        return (y + 1).cos()
+
+
+class AdditiveSDE(torch.nn.Module):
+    noise_type = 'additive'
+
     def __init__(self, d=10, m=3, sde_type=SDE_TYPES.ito):
-        super(AdditiveSDE, self).__init__(noise_type="additive", sde_type=sde_type)
+        super(AdditiveSDE, self).__init__()
+        self.sde_type = sde_type
         self.f_param = nn.Parameter(torch.randn(1, d), requires_grad=True)
         self.g_param = nn.Parameter(torch.sigmoid(torch.randn(1, d, m)), requires_grad=True)
 
@@ -129,10 +152,10 @@ class AdditiveSDE(BaseSDE):
 
 
 class ScalarSDE(AdditiveSDE):
-    def __init__(self, d=10, m=3):
-        super(ScalarSDE, self).__init__(d=d, m=m)
-        self.g_param = nn.Parameter(torch.sigmoid(torch.randn(1, d, 1)), requires_grad=True)
-        self.noise_type = "scalar"
+    noise_type = "scalar"
+
+    def __init__(self, d=10, sde_type=SDE_TYPES.ito):
+        super(ScalarSDE, self).__init__(d=d, m=1, sde_type=sde_type)
 
 
 class TupleSDE(SDEIto):

--- a/tests/test_sdeint.py
+++ b/tests/test_sdeint.py
@@ -16,11 +16,9 @@ import sys
 
 sys.path = sys.path[1:]  # A hack so that we always import the installed library.
 
-import contextlib
 import pytest
 import torch
 import torchsde
-import warnings
 
 from tests import basic_sde
 
@@ -38,6 +36,14 @@ t1 = 0.3
 T = 5
 dt = 1e-2
 dtype = torch.get_default_dtype()
+
+
+class _nullcontext:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
 
 
 @pytest.mark.parametrize('device', devices)
@@ -149,7 +155,7 @@ def _test_sdeint(sde, bm, method, adaptive, logqp, device, should_fail):
     if adaptive and method == 'euler' and sde.noise_type != 'additive':
         ctx = pytest.warns(UserWarning)
     else:
-        ctx = contextlib.nullcontext()
+        ctx = _nullcontext()
 
     # Using `f` as drift.
     with torch.no_grad():

--- a/torchsde/_core/base_solver.py
+++ b/torchsde/_core/base_solver.py
@@ -48,14 +48,14 @@ class BaseSDESolver(metaclass=better_abc.ABCMeta):
                  options: Dict,
                  **kwargs):
         super(BaseSDESolver, self).__init__(**kwargs)
-        assert sde.sde_type == self.sde_type, f"SDE is of type {sde.sde_type} but solver is for type {self.sde_type}"
-        assert sde.noise_type in self.noise_types, (
-            f"SDE has noise type {sde.noise_type} but solver only supports noise types {self.noise_types}"
-        )
-        assert bm.levy_area_approximation in self.levy_area_approximations, (
-            f"SDE solver requires one of {self.levy_area_approximations} set as the `levy_area_approximation` on the "
-            f"Brownian motion."
-        )
+        if sde.sde_type != self.sde_type:
+            raise ValueError(f"SDE is of type {sde.sde_type} but solver is for type {self.sde_type}")
+        if sde.noise_type not in self.noise_types:
+            raise ValueError(f"SDE has noise type {sde.noise_type} but solver only supports noise types "
+                             f"{self.noise_types}")
+        if bm.levy_area_approximation not in self.levy_area_approximations:
+            raise ValueError(f"SDE solver requires one of {self.levy_area_approximations} set as the "
+                             f"`levy_area_approximation` on the Brownian motion.")
         if sde.noise_type == NOISE_TYPES.scalar and torch.Size(bm.shape[1:]).numel() != 1:  # noqa
             raise ValueError("The Brownian motion for scalar SDEs must of dimension 1.")
 
@@ -96,7 +96,8 @@ class BaseSDESolver(metaclass=better_abc.ABCMeta):
         Returns:
             ys, where ys is a Tensor of size (T, batch_size, d).
         """
-        assert misc.is_strictly_increasing(ts), "Evaluation times `ts` must be strictly increasing."
+        if not misc.is_strictly_increasing(ts):
+            raise ValueError("Evaluation times `ts` must be strictly increasing.")
         y0, dt, adaptive, rtol, atol, dt_min = self.y0, self.dt, self.adaptive, self.rtol, self.atol, self.dt_min
 
         step_size = dt

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -120,7 +120,7 @@ def check_contract(sde, y0, ts, bm, method, names):
     if sde.sde_type not in SDE_TYPES:
         raise ValueError(f"Expected sde type in {SDE_TYPES}, but found {sde.sde_type}.")
 
-    method = select_default_method(sde, method)
+    method = select_default_method(sde, method, have_g=True)
 
     if method not in METHODS:
         raise ValueError(f"Expected method in {METHODS}, but found {method}.")
@@ -197,13 +197,14 @@ def check_contract(sde, y0, ts, bm, method, names):
     return sde, y0, ts, bm, method
 
 
-def select_default_method(sde: base_sde.BaseSDE, method: Optional[str]) -> str:
+def select_default_method(sde: base_sde.BaseSDE, method: Optional[str], have_g: bool) -> str:
+    ito_method = METHODS.srk if have_g else METHODS.milstein
     if method is None:
         method = {
             SDE_TYPES.ito: {
-                NOISE_TYPES.scalar: METHODS.srk,
-                NOISE_TYPES.additive: METHODS.srk,
-                NOISE_TYPES.diagonal: METHODS.srk,
+                NOISE_TYPES.scalar: ito_method,
+                NOISE_TYPES.additive: ito_method,
+                NOISE_TYPES.diagonal: ito_method,
                 NOISE_TYPES.general: METHODS.euler
             }[sde.noise_type],
             SDE_TYPES.stratonovich: METHODS.midpoint,

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -120,7 +120,16 @@ def check_contract(sde, y0, ts, bm, method, names):
     if sde.sde_type not in SDE_TYPES:
         raise ValueError(f"Expected sde type in {SDE_TYPES}, but found {sde.sde_type}.")
 
-    method = select_default_method(sde, method, have_g=True)
+    if method is None:
+        method = {
+            SDE_TYPES.ito: {
+                NOISE_TYPES.diagonal: METHODS.srk,
+                NOISE_TYPES.additive: METHODS.srk,
+                NOISE_TYPES.scalar: METHODS.srk,
+                NOISE_TYPES.general: METHODS.euler
+            }[sde.noise_type],
+            SDE_TYPES.stratonovich: METHODS.midpoint,
+        }[sde.sde_type]
 
     if method not in METHODS:
         raise ValueError(f"Expected method in {METHODS}, but found {method}.")
@@ -195,21 +204,6 @@ def check_contract(sde, y0, ts, bm, method, names):
                               device=y0.device, levy_area_approximation=levy_area_approximation)
 
     return sde, y0, ts, bm, method
-
-
-def select_default_method(sde: base_sde.BaseSDE, method: Optional[str], have_g: bool) -> str:
-    ito_method = METHODS.srk if have_g else METHODS.milstein
-    if method is None:
-        method = {
-            SDE_TYPES.ito: {
-                NOISE_TYPES.scalar: ito_method,
-                NOISE_TYPES.additive: ito_method,
-                NOISE_TYPES.diagonal: ito_method,
-                NOISE_TYPES.general: METHODS.euler
-            }[sde.noise_type],
-            SDE_TYPES.stratonovich: METHODS.midpoint,
-        }[sde.sde_type]
-    return method
 
 
 def integrate(sde, y0, ts, bm, method, dt, adaptive, rtol, atol, dt_min, options):


### PR DESCRIPTION
Ticking off a variety of smaller to-dos from #15 :
- Fixed adaptivity checks to not trigger for Heun etc.
- Improved default method selection to not use SRK when that's not appropriate. (Strat etc.)
- Updated `test_sdeint.py` to use pytest, and improved its test coverage.

The tests in `test_sdeint.py` are very numerous (~2000) covering all the common combinations of inputs, but are quick to run (~3 minutes); I felt it was best to be comprehensive on this central part of the library.

Thanks for your email btw - fortunately we've been doing different things, but I should have let you know!