### PR TITLE
Fixed BInterval test flakiness

### DIFF
--- a/tests/test_brownian_interval.py
+++ b/tests/test_brownian_interval.py
@@ -37,8 +37,7 @@ LARGE_BATCH_SIZE = 131072
 REPS = 2
 MEDIUM_REPS = 25
 LARGE_REPS = 500
-ALPHA = 0.0001
-POOL_SIZE = 48
+ALPHA = 0.00001
 
 devices = [cpu, gpu] = [torch.device('cpu'), torch.device('cuda')]
 
@@ -53,7 +52,7 @@ def _setup(device, levy_area_approximation, shape):
     tb = torch.rand([], device=device)
     ta, tb = min(ta, tb), max(ta, tb)
     bm = torchsde.BrownianInterval(t0=t0, t1=t1, size=shape, device=device,
-                                   levy_area_approximation=levy_area_approximation, pool_size=POOL_SIZE)
+                                   levy_area_approximation=levy_area_approximation)
     return ta, tb, bm
 
 
@@ -205,7 +204,7 @@ def test_normality_conditional(device, levy_area_approximation):
     t0, t1 = 0.0, 1.0
     for _ in range(REPS):
         bm = torchsde.BrownianInterval(t0=t0, t1=t1, size=(LARGE_BATCH_SIZE,), device=device,
-                                       levy_area_approximation=levy_area_approximation, pool_size=POOL_SIZE)
+                                       levy_area_approximation=levy_area_approximation)
 
         for _ in range(MEDIUM_REPS):
             ta, t_, tb = sorted(npr.uniform(low=t0, high=t1, size=(3,)))
@@ -268,7 +267,7 @@ def test_consistency(device, levy_area_approximation):
     t0, t1 = 0.0, 1.0
     for _ in range(REPS):
         bm = torchsde.BrownianInterval(t0=t0, t1=t1, size=(LARGE_BATCH_SIZE,), device=device,
-                                       levy_area_approximation=levy_area_approximation, pool_size=POOL_SIZE)
+                                       levy_area_approximation=levy_area_approximation)
 
         for _ in range(MEDIUM_REPS):
             ta, t_, tb = sorted(npr.uniform(low=t0, high=t1, size=(3,)))


### PR DESCRIPTION
Fixes the flakiness by decreasing alpha.

Looking at the number of times a pval check is made, with alpha=1e-4, the probability of getting a failure is 25% (under the null hypothesis). This is pretty high - it's no wonder we're seeing flakiness.

I've not figured out the exact Bonferroni-type corrections, but reducing this to alpha=1e-5 gives a probability of getting a failure as 3% (under the null hypothesis), which is still pretty high but probably tolerable. I've usually seen genuine failures giving pvals of 1e-180 or similar, so I don't think false negatives should be a serious issue.

I've also removed setting the pool size, as I think that's unnecessarily slowing things down.