### PR TITLE
Major bugfix + new efficiency-focused functionality.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -32,10 +32,10 @@ Several keyword arguments are also accepted, see [below](#keyword-arguments-of-s
 The output tensor `ys` will have shape `(t_size, batch_size, state_size)`, and corresponds to a sample from the SDE.
 
 ### Possible noise types
-- `scalar`: The diffusion `g` has output size `(batch_size, state_size, 1)`. The Brownian motion is 1-dimensional.
-- `additive`: The diffusion `g` is assumed to be constant w.r.t. `y` and has output size `(batch_size, state_size, brownian_size)`. The Brownian motion is `browian_size`-dimensional.
-- `diagonal`: The diffusion `g` is element-wise and has output size `(batch_size, state_size)`. The Brownian motion is `state_size`-dimensional.
-- `general`: The diffusion `g` has output size `(batch_size, state_size, brownian_size)`. The Brownian motion is `brownian_size`-dimensional.
+- `scalar`: The diffusion `g` has output size `(batch_size, state_size, 1)`. The Brownian motion is a batch of 1-dimensional Brownian motions.
+- `additive`: The diffusion `g` is assumed to be constant w.r.t. `y` and has output size `(batch_size, state_size, brownian_size)`. The Brownian motion is a batch of `browian_size`-dimensional Brownian motions.
+- `diagonal`: The diffusion `g` is element-wise and has output size `(batch_size, state_size)`. The Brownian motion is a batch of `state_size`-dimensional Brownian motions.
+- `general`: The diffusion `g` has output size `(batch_size, state_size, brownian_size)`. The Brownian motion is a batch of `brownian_size`-dimensional Brownian motions.
 
 ### Keyword arguments for `sdeint`
 - `bm`: A `BrownianInterval` object, see [below](#brownian-motion). Optionally include to control the Brownian motion.
@@ -64,6 +64,12 @@ The available solvers depends on the SDE type and the noise type.
 Note that Milstein and SRK don't support general noise.
 
 Additionally, [gradient-free Milstein](https://infoscience.epfl.ch/record/143450/files/sde_tutorial.pdf) can be used by selecting Milstein, and then also passing in the keyword argument `sdeint(..., options=dict(grad_free=True))`.
+
+
+### Providing special methods
+If your drift/diffusion have special structure, for example the drift and diffusion share some computations, then it may be more efficient to evaluate them together rather than alone. As such, if the following methods are present on `sde`, then they will be used if possible: `g_prod(t, y, v)`, `f_and_g(t, y)`, `f_and_g_prod(t, y, v)`. Here `g_prod` is expected to compute the batch matrix-vector product between the diffusion and the vector `v`. `f_and_*` should return a 2-tuple of `f(t, y)` and `g(t, y)`/`g_prod(t, y, v)` as appropriate.
+
+Depending on the integration method used it may suffice to provide only some of these methods (`f` and `g` are not mandatory).
 
 ## Adjoints
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -66,7 +66,7 @@ Note that Milstein and SRK don't support general noise.
 Additionally, [gradient-free Milstein](https://infoscience.epfl.ch/record/143450/files/sde_tutorial.pdf) can be used by selecting Milstein, and then also passing in the keyword argument `sdeint(..., options=dict(grad_free=True))`.
 
 
-### Providing special methods
+### Providing specialised methods
 If your drift/diffusion have special structure, for example the drift and diffusion share some computations, then it may be more efficient to evaluate them together rather than alone. As such, if the following methods are present on `sde`, then they will be used if possible: `g_prod(t, y, v)`, `f_and_g(t, y)`, `f_and_g_prod(t, y, v)`. Here `g_prod` is expected to compute the batch matrix-vector product between the diffusion and the vector `v`. `f_and_*` should return a 2-tuple of `f(t, y)` and `g(t, y)`/`g_prod(t, y, v)` as appropriate.
 
 Depending on the integration method used it may suffice to provide only some of these methods (`f` and `g` are not mandatory).

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ class SDE(torch.nn.Module):
         self.sigma = torch.nn.Linear(state_size, 
                                      state_size * brownian_size)
 
+    # Drift
     def f(self, t, y):
         return self.mu(y)  # shape (batch_size, state_size)
 
+    # Diffusion
     def g(self, t, y):
         return self.sigma(y).view(batch_size, 
                                   state_size, 

--- a/diagnostics/inspection.py
+++ b/diagnostics/inspection.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import os
+import sys
 
 import torch
 import tqdm
@@ -24,6 +24,10 @@ from torchsde.types import Tensor, Vector, Scalar, Tuple, Optional, Callable
 from . import utils
 
 
+sys.setrecursionlimit(5000)
+
+
+@torch.no_grad()
 def inspect_samples(y0: Tensor,
                     ts: Vector,
                     dt: Scalar,
@@ -32,15 +36,13 @@ def inspect_samples(y0: Tensor,
                     img_dir: str,
                     methods: Tuple[str, ...],
                     options: Optional[Tuple] = None,
+                    labels: Optional[Tuple[str, ...]] = None,
                     vis_dim=0,
-                    dt_true: Optional[float] = 2 ** -14,
-                    labels: Optional[Tuple[str, ...]] = None):
+                    dt_true: Optional[float] = 2 ** -14):
     if options is None:
         options = (None,) * len(methods)
     if labels is None:
         labels = methods
-
-    sde = copy.deepcopy(sde).requires_grad_(False)
 
     solns = [
         sdeint(sde, y0, ts, bm, method=method, dt=dt, options=options_)
@@ -66,6 +68,7 @@ def inspect_samples(y0: Tensor,
         )
 
 
+@torch.no_grad()
 def inspect_orders(y0: Tensor,
                    t0: Scalar,
                    t1: Scalar,
@@ -75,15 +78,14 @@ def inspect_orders(y0: Tensor,
                    img_dir: str,
                    methods: Tuple[str, ...],
                    options: Optional[Tuple] = None,
-                   dt_true: Optional[float] = 2 ** -14,
                    labels: Optional[Tuple[str, ...]] = None,
+                   dt_true: Optional[float] = 2 ** -14,
                    test_func: Optional[Callable] = lambda x: (x ** 2).flatten(start_dim=1).sum(dim=1)):
     if options is None:
         options = (None,) * len(methods)
     if labels is None:
         labels = methods
 
-    sde = copy.deepcopy(sde).requires_grad_(False)
     ts = torch.tensor([t0, t1], device=y0.device)
 
     solns = [

--- a/diagnostics/ito_diagonal.py
+++ b/diagnostics/ito_diagonal.py
@@ -16,7 +16,7 @@ import os
 
 import torch
 
-from tests.problems import Ex1
+from tests.problems import NeuralDiagonal
 from torchsde import BrownianInterval
 from torchsde.settings import LEVY_AREA_APPROXIMATIONS
 from . import inspection
@@ -24,14 +24,18 @@ from . import utils
 
 
 def main():
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    torch.set_default_dtype(torch.float64)
+    utils.manual_seed()
+
     small_batch_size, large_batch_size, d = 16, 16384, 5
     t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
-    sde = Ex1(d=d).to(device)
-    methods = ('euler', 'srk', 'milstein', 'milstein')
-    options = (None, None, None, dict(grad_free=True))
-    labels = ('euler', 'srk', 'milstein', 'grad-free milstein')
+    sde = NeuralDiagonal(d=d).to(device)
+    methods = ('euler', 'milstein', 'milstein', 'srk')
+    options = (None, None, dict(grad_free=True), None)
+    labels = ('euler', 'milstein', 'gradient-free milstein', 'srk')
     img_dir = os.path.join(os.path.dirname(__file__), 'plots', 'ito_diagonal')
 
     y0 = torch.full((small_batch_size, d), fill_value=0.1, device=device)
@@ -39,19 +43,15 @@ def main():
         t0=t0, t1=t1, size=(small_batch_size, d), dtype=y0.dtype, device=device,
         levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time
     )
-    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods, options=options, labels=labels)
+    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods, options, labels)
 
     y0 = torch.full((large_batch_size, d), fill_value=0.1, device=device)
     bm = BrownianInterval(
         t0=t0, t1=t1, size=(large_batch_size, d), dtype=y0.dtype, device=device,
         levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time
     )
-    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods, options=options, labels=labels)
+    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods, options, labels)
 
 
 if __name__ == '__main__':
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    torch.set_default_dtype(torch.float64)
-    utils.manual_seed()
-
     main()

--- a/diagnostics/ito_scalar.py
+++ b/diagnostics/ito_scalar.py
@@ -16,20 +16,26 @@ import os
 
 import torch
 
-from tests.problems import Ex2
+from tests.problems import NeuralScalar
 from torchsde import BrownianInterval
-from torchsde.settings import LEVY_AREA_APPROXIMATIONS, NOISE_TYPES
+from torchsde.settings import LEVY_AREA_APPROXIMATIONS
 from . import inspection
 from . import utils
 
 
 def main():
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    torch.set_default_dtype(torch.float64)
+    utils.manual_seed()
+
     small_batch_size, large_batch_size, d = 16, 16384, 5
     t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
-    sde = Ex2(d=d).to(device)
-    methods = ('euler', 'srk', 'milstein')
+    sde = NeuralScalar(d=d).to(device)
+    methods = ('euler', 'milstein', 'milstein', 'srk')
+    options = (None, None, dict(grad_free=True), None)
+    labels = ('euler', 'milstein', 'gradient-free milstein', 'srk')
     img_dir = os.path.join(os.path.dirname(__file__), 'plots', 'ito_scalar')
 
     y0 = torch.full((small_batch_size, d), fill_value=0.1, device=device)
@@ -37,19 +43,15 @@ def main():
         t0=t0, t1=t1, size=(small_batch_size, 1), dtype=y0.dtype, device=device,
         levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time
     )
-    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods)
+    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods, options, labels)
 
     y0 = torch.full((large_batch_size, d), fill_value=0.1, device=device)
     bm = BrownianInterval(
         t0=t0, t1=t1, size=(large_batch_size, 1), dtype=y0.dtype, device=device,
         levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time
     )
-    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods)
+    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods, options, labels)
 
 
 if __name__ == '__main__':
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    torch.set_default_dtype(torch.float64)
-    utils.manual_seed()
-
     main()

--- a/diagnostics/run_all.py
+++ b/diagnostics/run_all.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from . import ito_additive, ito_diagonal, ito_general, ito_scalar
 from . import stratonovich_additive, stratonovich_diagonal, stratonovich_general, stratonovich_scalar
 

--- a/diagnostics/run_all.py
+++ b/diagnostics/run_all.py
@@ -1,0 +1,7 @@
+from . import ito_additive, ito_diagonal, ito_general, ito_scalar
+from . import stratonovich_additive, stratonovich_diagonal, stratonovich_general, stratonovich_scalar
+
+if __name__ == '__main__':
+    for module in (ito_additive, ito_diagonal, ito_general, ito_scalar, stratonovich_additive, stratonovich_diagonal,
+                   stratonovich_general, stratonovich_scalar):
+        module.main()

--- a/diagnostics/stratonovich_additive.py
+++ b/diagnostics/stratonovich_additive.py
@@ -16,7 +16,7 @@ import os
 
 import torch
 
-from tests.basic_sde import AdditiveSDE
+from tests.problems import NeuralAdditive
 from torchsde import BrownianInterval
 from torchsde.settings import LEVY_AREA_APPROXIMATIONS, SDE_TYPES
 from . import inspection
@@ -24,34 +24,36 @@ from . import utils
 
 
 def main():
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    torch.set_default_dtype(torch.float64)
+    utils.manual_seed()
+
     small_batch_size, large_batch_size, d, m = 16, 16384, 3, 5
     t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
-    sde = AdditiveSDE(d=d, m=m, sde_type=SDE_TYPES.stratonovich).to(device)
-    # Don't test Milstein methods, since there's no advantage to use extra resource to compute 0s.
-    methods = ('heun', 'euler_heun', 'midpoint')
-    labels = ('heun', 'euler-heun', 'midpoint')
+    sde = NeuralAdditive(d=d, m=m, sde_type=SDE_TYPES.stratonovich).to(device)
+    # Milstein and log-ODE should in theory both superfluously compute zeros here.
+    # We include them anyway to check that they do what they claim to do.
+    methods = ('euler_heun', 'heun', 'midpoint', 'milstein', 'milstein', 'log_ode')
+    options = (None, None, None, None, dict(grad_free=True), None)
+    labels = ('euler-heun', 'heun', 'midpoint', 'milstein', 'grad-free milstein', 'log_ode')
     img_dir = os.path.join(os.path.dirname(__file__), 'plots', 'stratonovich_additive')
 
     y0 = torch.full((small_batch_size, d), fill_value=0.1, device=device)
     bm = BrownianInterval(
         t0=t0, t1=t1, size=(small_batch_size, m), dtype=y0.dtype, device=device,
-        levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time
+        levy_area_approximation=LEVY_AREA_APPROXIMATIONS.foster
     )
-    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods, labels=labels)
+    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods, options, labels)
 
     y0 = torch.full((large_batch_size, d), fill_value=0.1, device=device)
     bm = BrownianInterval(
         t0=t0, t1=t1, size=(large_batch_size, m), dtype=y0.dtype, device=device,
-        levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time
+        levy_area_approximation=LEVY_AREA_APPROXIMATIONS.foster
     )
-    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods, labels=labels)
+    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods, options, labels)
 
 
 if __name__ == '__main__':
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    torch.set_default_dtype(torch.float64)
-    utils.manual_seed()
-
     main()

--- a/diagnostics/stratonovich_diagonal.py
+++ b/diagnostics/stratonovich_diagonal.py
@@ -16,7 +16,7 @@ import os
 
 import torch
 
-from tests.problems import Ex1
+from tests.problems import NeuralDiagonal
 from torchsde import BrownianInterval
 from torchsde.settings import LEVY_AREA_APPROXIMATIONS, SDE_TYPES
 from . import inspection
@@ -24,34 +24,34 @@ from . import utils
 
 
 def main():
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    torch.set_default_dtype(torch.float64)
+    utils.manual_seed()
+
     small_batch_size, large_batch_size, d = 16, 16384, 3
     t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
-    sde = Ex1(d=d, sde_type=SDE_TYPES.stratonovich).to(device)
-    methods = ('heun', 'euler_heun', 'midpoint', 'milstein', 'milstein')
-    options = (None, None, None, None, dict(grad_free=True))
-    labels = ('heun', 'euler-heun', 'midpoint', 'milstein', 'grad-free milstein')
+    sde = NeuralDiagonal(d=d, sde_type=SDE_TYPES.stratonovich).to(device)
+    methods = ('euler_heun', 'heun', 'midpoint', 'milstein', 'milstein', 'log_ode')
+    options = (None, None, None, None, dict(grad_free=True), None)
+    labels = ('euler-heun', 'heun', 'midpoint', 'milstein', 'grad-free milstein', 'log_ode')
     img_dir = os.path.join(os.path.dirname(__file__), 'plots', 'stratonovich_diagonal')
 
     y0 = torch.full((small_batch_size, d), fill_value=0.1, device=device)
     bm = BrownianInterval(
         t0=t0, t1=t1, size=(small_batch_size, d), dtype=y0.dtype, device=device,
-        levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time
+        levy_area_approximation=LEVY_AREA_APPROXIMATIONS.foster
     )
-    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods, options=options, labels=labels)
+    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods, options, labels)
 
     y0 = torch.full((large_batch_size, d), fill_value=0.1, device=device)
     bm = BrownianInterval(
         t0=t0, t1=t1, size=(large_batch_size, d), dtype=y0.dtype, device=device,
-        levy_area_approximation=LEVY_AREA_APPROXIMATIONS.space_time
+        levy_area_approximation=LEVY_AREA_APPROXIMATIONS.foster
     )
-    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods, options=options, labels=labels)
+    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods, options, labels)
 
 
 if __name__ == '__main__':
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    torch.set_default_dtype(torch.float64)
-    utils.manual_seed()
-
     main()

--- a/diagnostics/stratonovich_general.py
+++ b/diagnostics/stratonovich_general.py
@@ -16,7 +16,7 @@ import os
 
 import torch
 
-from tests.problems import Ex4
+from tests.problems import NeuralGeneral
 from torchsde import BrownianInterval
 from torchsde.settings import LEVY_AREA_APPROXIMATIONS, SDE_TYPES
 from . import inspection
@@ -24,12 +24,19 @@ from . import utils
 
 
 def main():
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    torch.set_default_dtype(torch.float64)
+    utils.manual_seed()
+
     small_batch_size, large_batch_size, d, m = 16, 16384, 3, 5
     t0, t1, steps, dt = 0., 2., 10, 1e-1
     ts = torch.linspace(t0, t1, steps=steps, device=device)
     dts = tuple(2 ** -i for i in range(1, 7))  # For checking strong order.
-    sde = Ex4(d=d, m=m, sde_type=SDE_TYPES.stratonovich).to(device)
-    methods = ('midpoint', 'log_ode')
+    sde = NeuralGeneral(d=d, m=m, sde_type=SDE_TYPES.stratonovich).to(device)
+    # Don't include Milstein as it doesn't work for general noise.
+    methods = ('euler_heun', 'heun', 'midpoint', 'log_ode')
+    options = (None, None, None, None)
+    labels = ('euler_heun', 'heun', 'midpoint', 'log_ode')
     img_dir = os.path.join(os.path.dirname(__file__), 'plots', 'stratonovich_general')
 
     y0 = torch.full((small_batch_size, d), fill_value=0.1, device=device)
@@ -37,19 +44,15 @@ def main():
         t0=t0, t1=t1, size=(small_batch_size, m), dtype=y0.dtype, device=device,
         levy_area_approximation=LEVY_AREA_APPROXIMATIONS.foster
     )
-    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods)
+    inspection.inspect_samples(y0, ts, dt, sde, bm, img_dir, methods, options, labels)
 
     y0 = torch.full((large_batch_size, d), fill_value=0.1, device=device)
     bm = BrownianInterval(
         t0=t0, t1=t1, size=(large_batch_size, m), dtype=y0.dtype, device=device,
         levy_area_approximation=LEVY_AREA_APPROXIMATIONS.foster
     )
-    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods)
+    inspection.inspect_orders(y0, t0, t1, dts, sde, bm, img_dir, methods, options, labels)
 
 
 if __name__ == '__main__':
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    torch.set_default_dtype(torch.float64)
-    utils.manual_seed()
-
     main()

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     description="SDE solvers and stochastic adjoint sensitivity analysis in PyTorch.",
     url="https://github.com/google-research/torchsde",
     packages=setuptools.find_packages(exclude=['benchmarks', 'diagnostics', 'examples', 'tests']),
-    install_requires=['torch>=1.6.0', 'numpy>=1.19.1', 'boltons>=20.2.1', 'trampoline>=0.1.2', 'scipy>=1.5.2'],
+    install_requires=['torch>=1.6.0', 'numpy==1.19.*', 'boltons>=20.2.1', 'trampoline>=0.1.2', 'scipy==1.5.*'],
     python_requires='~=3.6',
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -16,13 +16,12 @@
 
 Each example is of a particular noise type.
 
-Ex1, Ex2, Ex3 from
-
+ExDiagonal, ExScalar, ExAdditive are examples 1-3 from
 Rackauckas, Christopher, and Qing Nie. "Adaptive methods for stochastic
 differential equations via natural embeddings and rejection sampling with memory."
 Discrete and continuous dynamical systems. Series B 22.7 (2017): 2731.
 
-Ex4 is constructed to test schemes for SDEs with general noise and neural nets.
+Neural* all use simple neural networks.
 
 BasicSDE1-4 are problems where the drift and diffusion may not depend on
 trainable parameters.
@@ -37,11 +36,11 @@ from torchsde import BaseSDE, SDEIto
 from torchsde.settings import NOISE_TYPES, SDE_TYPES
 
 
-class Ex1(BaseSDE):
+class ExDiagonal(BaseSDE):
     noise_type = NOISE_TYPES.diagonal
 
     def __init__(self, d, sde_type=SDE_TYPES.ito, **kwargs):
-        super(Ex1, self).__init__(sde_type=sde_type, noise_type=Ex1.noise_type)
+        super(ExDiagonal, self).__init__(sde_type=sde_type, noise_type=ExDiagonal.noise_type)
         self._nfe = 0
 
         # Use non-exploding initialization.
@@ -73,11 +72,11 @@ class Ex1(BaseSDE):
         return self._nfe
 
 
-class Ex2(BaseSDE):
+class ExScalar(BaseSDE):
     noise_type = NOISE_TYPES.scalar
 
     def __init__(self, d, sde_type=SDE_TYPES.ito, **kwargs):
-        super(Ex2, self).__init__(sde_type=sde_type, noise_type=Ex2.noise_type)
+        super(ExScalar, self).__init__(sde_type=sde_type, noise_type=ExScalar.noise_type)
         self._nfe = 0
         self.p = nn.Parameter(torch.sigmoid(torch.randn(d)), requires_grad=True)
 
@@ -104,11 +103,11 @@ class Ex2(BaseSDE):
         return self._nfe
 
 
-class Ex3(BaseSDE):
+class ExAdditive(BaseSDE):
     noise_type = NOISE_TYPES.additive
 
     def __init__(self, d, m, sde_type=SDE_TYPES.ito, **kwargs):
-        super(Ex3, self).__init__(sde_type=sde_type, noise_type=Ex3.noise_type)
+        super(ExAdditive, self).__init__(sde_type=sde_type, noise_type=ExAdditive.noise_type)
         self._nfe = 0
         self.m = m
 
@@ -133,44 +132,127 @@ class Ex3(BaseSDE):
         return self._nfe
 
 
-class Ex4(BaseSDE):
-    noise_type = NOISE_TYPES.general
+class NeuralDiagonal(BaseSDE):
+    noise_type = NOISE_TYPES.diagonal
 
-    def __init__(self, d, m, sde_type=SDE_TYPES.ito, **kwargs):
-        super(Ex4, self).__init__(sde_type=sde_type, noise_type=Ex4.noise_type)
-        self._nfe = 0
-        self.d = d
-        self.m = m
+    def __init__(self, d, sde_type=SDE_TYPES.ito, **kwargs):
+        super(NeuralDiagonal, self).__init__(sde_type=sde_type, noise_type=NeuralDiagonal.noise_type)
 
         self.f_net = nn.Sequential(
-            nn.Linear(d + 1, 3),
+            nn.Linear(d + 1, 8),
             nn.Softplus(),
-            nn.Linear(3, d)
+            nn.Linear(8, d)
         )
         self.g_net = nn.Sequential(
-            nn.Linear(d + 1, 3),
+            nn.Linear(d + 1, 8),
             nn.Softplus(),
-            nn.Linear(3, d * m),
+            nn.Linear(8, d),
             nn.Sigmoid()
         )
 
     def f(self, t, y):
-        self._nfe += 1
-        ty = torch.cat((t.expand_as(y[:, :1]), y), dim=1)
+        ty = torch.cat([t.expand(y.size(0), 1), y], dim=1)
         return self.f_net(ty)
 
     def g(self, t, y):
-        self._nfe += 1
-        ty = torch.cat((t.expand_as(y[:, :1]), y), dim=1)
-        return self.g_net(ty).reshape(-1, self.d, self.m)
+        ty = torch.cat([t.expand(y.size(0), 1), y], dim=1)
+        return self.g_net(ty)
 
     def h(self, t, y):
-        self._nfe += 1
         return torch.zeros_like(y)
 
-    @property
-    def nfe(self):
-        return self._nfe
+
+class NeuralScalar(BaseSDE):
+    noise_type = NOISE_TYPES.scalar
+
+    def __init__(self, d, sde_type=SDE_TYPES.ito, **kwargs):
+        super(NeuralScalar, self).__init__(sde_type=sde_type, noise_type=NeuralScalar.noise_type)
+
+        self.f_net = nn.Sequential(
+            nn.Linear(d + 1, 8),
+            nn.Softplus(),
+            nn.Linear(8, d)
+        )
+        self.g_net = nn.Sequential(
+            nn.Linear(d + 1, 8),
+            nn.Softplus(),
+            nn.Linear(8, d),
+            nn.Sigmoid()
+        )
+
+    def f(self, t, y):
+        ty = torch.cat([t.expand(y.size(0), 1), y], dim=1)
+        return self.f_net(ty)
+
+    def g(self, t, y):
+        ty = torch.cat([t.expand(y.size(0), 1), y], dim=1)
+        return self.g_net(ty).unsqueeze(-1)
+
+    def h(self, t, y):
+        return torch.zeros_like(y)
+
+
+class NeuralAdditive(BaseSDE):
+    noise_type = NOISE_TYPES.additive
+
+    def __init__(self, d, m, sde_type=SDE_TYPES.ito, **kwargs):
+        super(NeuralAdditive, self).__init__(sde_type=sde_type, noise_type=NeuralAdditive.noise_type)
+        self.d = d
+        self.m = m
+
+        self.f_net = nn.Sequential(
+            nn.Linear(d + 1, 8),
+            nn.Softplus(),
+            nn.Linear(8, d)
+        )
+        self.g_net = nn.Sequential(
+            nn.Linear(1, 8),
+            nn.Softplus(),
+            nn.Linear(8, d * m),
+            nn.Sigmoid()
+        )
+
+    def f(self, t, y):
+        ty = torch.cat([t.expand(y.size(0), 1), y], dim=1)
+        return self.f_net(ty)
+
+    def g(self, t, y):
+        return self.g_net(t.expand(y.size(0), 1)).view(y.size(0), self.d, self.m)
+
+    def h(self, t, y):
+        return torch.zeros_like(y)
+
+
+class NeuralGeneral(BaseSDE):
+    noise_type = NOISE_TYPES.general
+
+    def __init__(self, d, m, sde_type=SDE_TYPES.ito, **kwargs):
+        super(NeuralGeneral, self).__init__(sde_type=sde_type, noise_type=NeuralGeneral.noise_type)
+        self.d = d
+        self.m = m
+
+        self.f_net = nn.Sequential(
+            nn.Linear(d + 1, 8),
+            nn.Softplus(),
+            nn.Linear(8, d)
+        )
+        self.g_net = nn.Sequential(
+            nn.Linear(d + 1, 8),
+            nn.Softplus(),
+            nn.Linear(8, d * m),
+            nn.Sigmoid()
+        )
+
+    def f(self, t, y):
+        ty = torch.cat([t.expand(y.size(0), 1), y], dim=1)
+        return self.f_net(ty)
+
+    def g(self, t, y):
+        ty = torch.cat([t.expand(y.size(0), 1), y], dim=1)
+        return self.g_net(ty).reshape(y.size(0), self.d, self.m)
+
+    def h(self, t, y):
+        return torch.zeros_like(y)
 
 
 class BasicSDE1(SDEIto):

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -351,3 +351,90 @@ class CustomNamesSDELogqp(SDEIto):
 
     def w(self, t, y):
         return y * t
+
+
+class FGSDE(torch.nn.Module):
+    noise_type = 'general'
+
+    def __init__(self, sde_type, vector):
+        super(FGSDE, self).__init__()
+        self.sde_type = sde_type
+        self.register_buffer('vector', vector)
+
+    def f(self, t, y):
+        return -y
+
+    def g(self, t, y):
+        return y.unsqueeze(-1).sigmoid() * self.vector
+
+
+class FAndGSDE(torch.nn.Module):
+    noise_type = 'general'
+
+    def __init__(self, sde_type, vector):
+        super(FAndGSDE, self).__init__()
+        self.sde_type = sde_type
+        self.register_buffer('vector', vector)
+
+    def f_and_g(self, t, y):
+        return -y, y.unsqueeze(-1).sigmoid() * self.vector
+
+
+class GProdSDE(torch.nn.Module):
+    noise_type = 'general'
+
+    def __init__(self, sde_type, vector):
+        super(GProdSDE, self).__init__()
+        self.sde_type = sde_type
+        self.register_buffer('vector', vector)
+
+    def f(self, t, y):
+        return -y
+
+    def g_prod(self, t, y, v):
+        return (y.unsqueeze(-1).sigmoid() * self.vector).bmm(v.unsqueeze(-1)).squeeze(-1)
+
+
+class FAndGProdSDE(torch.nn.Module):
+    noise_type = 'general'
+
+    def __init__(self, sde_type, vector):
+        super(FAndGProdSDE, self).__init__()
+        self.sde_type = sde_type
+        self.register_buffer('vector', vector)
+
+    def f_and_g_prod(self, t, y, v):
+        return -y, (y.unsqueeze(-1).sigmoid() * self.vector).bmm(v.unsqueeze(-1)).squeeze(-1)
+
+
+class FAndGGProdSDE1(torch.nn.Module):
+    noise_type = 'general'
+
+    def __init__(self, sde_type, vector):
+        super(FAndGGProdSDE1, self).__init__()
+        self.sde_type = sde_type
+        self.register_buffer('vector', vector)
+
+    def f_and_g(self, t, y):
+        return -y, y.unsqueeze(-1).sigmoid() * self.vector
+
+    def g_prod(self, t, y, v):
+        return (y.unsqueeze(-1).sigmoid() * self.vector).bmm(v.unsqueeze(-1)).squeeze(-1)
+
+
+class FAndGGProdSDE2(torch.nn.Module):
+    noise_type = 'general'
+
+    def __init__(self, sde_type, vector):
+        super(FAndGGProdSDE2, self).__init__()
+        self.sde_type = sde_type
+        self.register_buffer('vector', vector)
+
+    def f(self, t, y):
+        return -y
+
+    def f_and_g(self, t, y):
+        return -y, y.unsqueeze(-1).sigmoid() * self.vector
+
+    def g_prod(self, t, y, v):
+        return (y.unsqueeze(-1).sigmoid() * self.vector).bmm(v.unsqueeze(-1)).squeeze(-1)

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -37,7 +37,7 @@ ito_methods = {'milstein': 'ito', 'srk': 'ito'}
 stratonovich_methods = {'midpoint': 'stratonovich'}
 
 
-@pytest.mark.parametrize("sde_cls", [problems.Ex1, problems.Ex2, problems.Ex3, problems.Ex4])
+@pytest.mark.parametrize("sde_cls", [problems.ExDiagonal, problems.ExScalar, problems.ExAdditive, problems.NeuralGeneral])
 @pytest.mark.parametrize("method, sde_type", itertools.chain(ito_methods.items(), stratonovich_methods.items()))
 @pytest.mark.parametrize('adaptive', (False,))
 def test_adjoint(sde_cls, method, sde_type, adaptive):

--- a/tests/test_sdeint.py
+++ b/tests/test_sdeint.py
@@ -29,13 +29,13 @@ devices = ['cpu']
 if torch.cuda.is_available():
     devices.append('cuda')
 
-batch_size = 16
+batch_size = 4
 d = 3
 m = 2
 t0 = 0.0
 t1 = 0.3
 T = 5
-dt = 1e-2
+dt = 0.05
 dtype = torch.get_default_dtype()
 
 
@@ -76,7 +76,8 @@ def _use_bm__levy_area_approximation():
     yield True, 'foster'
 
 
-@pytest.mark.parametrize('sde_cls', [problems.Ex1, problems.Ex2, problems.Ex4, problems.Ex4])
+@pytest.mark.parametrize('sde_cls', [problems.ExDiagonal, problems.ExScalar, problems.ExAdditive,
+                                     problems.NeuralGeneral])
 @pytest.mark.parametrize('use_bm,levy_area_approximation', _use_bm__levy_area_approximation())
 @pytest.mark.parametrize('sde_type', ['ito', 'stratonovich'])
 @pytest.mark.parametrize('method', ['blah', 'euler', 'milstein', 'srk', 'euler_heun', 'heun', 'midpoint', 'log_ode'])

--- a/torchsde/_core/adjoint.py
+++ b/torchsde/_core/adjoint.py
@@ -176,12 +176,16 @@ def sdeint_adjoint(sde: nn.Module,
             or `sde` is missing required methods.
 
     Note:
-        Double-backward is supported, and will use the adjoint method to compute
-        the gradient of the adjoint. (i.e. rather than backpropagating through
-        the numerical solver used for the adjoint.) The same `adjoint_method`,
-        `adjoint_adaptive`, `adjoint_rtol, `adjoint_atol`, `adjoint_options`
-        will be used for the second-order adjoint as is used for the first-order
-        adjoint.
+        The backward pass is much more efficient with Stratonovich SDEs than
+        with Ito SDEs.
+
+    Note:
+        Double-backward is supported for Stratonovich SDEs. Doing so will use
+        the adjoint method to compute the gradient of the adjoint. (i.e. rather
+        than backpropagating through the numerical solver used for the
+        adjoint.) The same `adjoint_method`, `adjoint_adaptive`, `adjoint_rtol,
+        `adjoint_atol`, `adjoint_options` will be used for the second-order
+        adjoint as is used for the first-order adjoint.
     """
     misc.handle_unused_kwargs(unused_kwargs, msg="`sdeint_adjoint`")
     del unused_kwargs

--- a/torchsde/_core/adjoint_sde.py
+++ b/torchsde/_core/adjoint_sde.py
@@ -54,9 +54,22 @@ class AdjointSDE(base_sde.BaseSDE):
             }.get(sde.noise_type),
             SDE_TYPES.stratonovich: self.f_uncorrected
         }.get(sde.sde_type)
+        self.f_and_g_prod = {
+            SDE_TYPES.ito: {
+                NOISE_TYPES.diagonal: self.f_and_g_prod_corrected_diagonal,
+                NOISE_TYPES.additive: self.f_and_g_prod_uncorrected,
+                NOISE_TYPES.scalar: self.f_and_g_prod_corrected_default,
+                NOISE_TYPES.general: self.f_and_g_prod_corrected_default
+            }.get(sde.noise_type),
+            SDE_TYPES.stratonovich: self.f_and_g_prod_uncorrected
+        }.get(sde.sde_type)
         self.gdg_prod = {
             NOISE_TYPES.diagonal: self.gdg_prod_diagonal,
         }.get(sde.noise_type, self.gdg_prod_default)
+
+    ########################################
+    #            Helper functions          #
+    ########################################
 
     def _get_state(self, t, y_aug, v=None):
         """Unpacks y_aug, whilst enforcing the necessary checks so that we can calculate derivatives wrt state."""
@@ -92,6 +105,125 @@ class AdjointSDE(base_sde.BaseSDE):
             y = y.detach().requires_grad_(True)
         return y, adj_y, requires_grad
 
+    def _f_uncorrected(self, f, y, adj_y, requires_grad):
+        vjp_y_and_params = misc.vjp(
+            outputs=f,
+            inputs=[y] + self._params,
+            grad_outputs=adj_y,
+            allow_unused=True,
+            retain_graph=True,
+            create_graph=requires_grad
+        )
+        if not requires_grad:
+            # We had to build a computational graph to be able to compute the above vjp.
+            # However, if we don't require_grad then we don't need to backprop through this function, so we should
+            # delete the computational graph to avoid a memory leak. (Which for example would keep the local
+            # variable `y` in memory: f->grad_fn->...->AccumulatedGrad->y.)
+            f = f.detach()
+        return misc.flatten((-f, *vjp_y_and_params))
+
+    def _f_corrected_default(self, f, g, y, adj_y, requires_grad):
+        g_columns = [g_column.squeeze(dim=-1) for g_column in g.split(1, dim=-1)]
+        dg_g_jvp = sum([
+            misc.jvp(
+                outputs=g_column,
+                inputs=y,
+                grad_inputs=g_column,
+                allow_unused=True,
+                create_graph=True
+            )[0] for g_column in g_columns
+        ])
+        # Double Stratonovich correction.
+        f = f - dg_g_jvp
+        vjp_y_and_params = misc.vjp(
+            outputs=f,
+            inputs=[y] + self._params,
+            grad_outputs=adj_y,
+            allow_unused=True,
+            retain_graph=True,
+            create_graph=requires_grad
+        )
+        # Convert the adjoint Stratonovich SDE to Itô form.
+        extra_vjp_y_and_params = []
+        for g_column in g_columns:
+            a_dg_vjp, = misc.vjp(
+                outputs=g_column,
+                inputs=y,
+                grad_outputs=adj_y,
+                allow_unused=True,
+                retain_graph=True,
+                create_graph=requires_grad
+            )
+            extra_vjp_y_and_params_column = misc.vjp(
+                outputs=g_column,
+                inputs=[y] + self._params,
+                grad_outputs=a_dg_vjp,
+                allow_unused=True,
+                retain_graph=True,
+                create_graph=requires_grad
+            )
+            extra_vjp_y_and_params.append(extra_vjp_y_and_params_column)
+        vjp_y_and_params = misc.seq_add(vjp_y_and_params, *extra_vjp_y_and_params)
+        if not requires_grad:
+            # See corresponding note in _f_uncorrected.
+            f = f.detach()
+        return misc.flatten((-f, *vjp_y_and_params))
+
+    def _f_corrected_diagonal(self, f, g, y, adj_y, requires_grad):
+        g_dg_vjp, = misc.vjp(
+            outputs=g,
+            inputs=y,
+            grad_outputs=g,
+            allow_unused=True,
+            create_graph=True
+        )
+        # Double Stratonovich correction.
+        f = f - g_dg_vjp
+        vjp_y_and_params = misc.vjp(
+            outputs=f,
+            inputs=[y] + self._params,
+            grad_outputs=adj_y,
+            allow_unused=True,
+            retain_graph=True,
+            create_graph=requires_grad
+        )
+        # Convert the adjoint Stratonovich SDE to Itô form.
+        a_dg_vjp, = misc.vjp(
+            outputs=g,
+            inputs=y,
+            grad_outputs=adj_y,
+            allow_unused=True,
+            retain_graph=True,
+            create_graph=requires_grad
+        )
+        extra_vjp_y_and_params = misc.vjp(
+            outputs=g,
+            inputs=[y] + self._params,
+            grad_outputs=a_dg_vjp,
+            allow_unused=True,
+            retain_graph=True,
+            create_graph=requires_grad
+        )
+        vjp_y_and_params = misc.seq_add(vjp_y_and_params, extra_vjp_y_and_params)
+        if not requires_grad:
+            # See corresponding note in _f_uncorrected.
+            f = f.detach()
+        return misc.flatten((-f, *vjp_y_and_params))
+
+    def _g_prod(self, g_prod, y, adj_y, requires_grad):
+        vjp_y_and_params = misc.vjp(
+            outputs=g_prod,
+            inputs=[y] + self._params,
+            grad_outputs=adj_y,
+            allow_unused=True,
+            retain_graph=True,
+            create_graph=requires_grad
+        )
+        if not requires_grad:
+            # See corresponding note in f_uncorrected.
+            g_prod = g_prod.detach()
+        return misc.flatten((-g_prod, *vjp_y_and_params))
+
     ########################################
     #                  f                   #
     ########################################
@@ -100,110 +232,19 @@ class AdjointSDE(base_sde.BaseSDE):
         y, adj_y, requires_grad = self._get_state(t, y_aug)
         with torch.enable_grad():
             f = self._base_sde.f(-t, y)
-            vjp_y_and_params = misc.vjp(
-                outputs=f,
-                inputs=[y] + self._params,
-                grad_outputs=adj_y,
-                allow_unused=True,
-                create_graph=requires_grad
-            )
-            if not requires_grad:
-                # We had to build a computational graph to be able to compute the above vjp.
-                # However, if we don't require_grad then we don't need to backprop through this function, so we should
-                # delete the computational graph to avoid a memory leak. (Which for example would keep the local
-                # variable `y` in memory: f->grad_fn->...->AccumulatedGrad->y.)
-                f = f.detach()
-        return misc.flatten((-f, *vjp_y_and_params))
+            return self._f_uncorrected(f, y, adj_y, requires_grad)
 
     def f_corrected_default(self, t, y_aug):  # For Ito general/scalar.
         y, adj_y, requires_grad = self._get_state(t, y_aug)
         with torch.enable_grad():
-            g_columns = [g_column.squeeze(dim=-1) for g_column in self._base_sde.g(-t, y).split(1, dim=-1)]
-            dg_g_jvp = sum([
-                misc.jvp(
-                    outputs=g_column,
-                    inputs=y,
-                    grad_inputs=g_column,
-                    allow_unused=True,
-                    create_graph=True
-                )[0] for g_column in g_columns
-            ])
-            # Double Stratonovich correction.
-            f = self._base_sde.f(-t, y) - dg_g_jvp
-            vjp_y_and_params = misc.vjp(
-                outputs=f,
-                inputs=[y] + self._params,
-                grad_outputs=adj_y,
-                allow_unused=True,
-                retain_graph=True,
-                create_graph=requires_grad
-            )
-            # Convert the adjoint Stratonovich SDE to Itô form.
-            extra_vjp_y_and_params = []
-            for g_column in g_columns:
-                a_dg_vjp, = misc.vjp(
-                    outputs=g_column,
-                    inputs=y,
-                    grad_outputs=adj_y,
-                    allow_unused=True,
-                    retain_graph=True,
-                    create_graph=requires_grad
-                )
-                extra_vjp_y_and_params_column = misc.vjp(
-                    outputs=g_column,
-                    inputs=[y] + self._params,
-                    grad_outputs=a_dg_vjp,
-                    allow_unused=True,
-                    create_graph=requires_grad
-                )
-                extra_vjp_y_and_params.append(extra_vjp_y_and_params_column)
-            vjp_y_and_params = misc.seq_add(vjp_y_and_params, *extra_vjp_y_and_params)
-            if not requires_grad:
-                f = f.detach()
-        return misc.flatten((-f, *vjp_y_and_params))
+            f, g = self._base_sde.f_and_g(-t, y)
+            return self._f_corrected_default(f, g, y, adj_y, requires_grad)
 
     def f_corrected_diagonal(self, t, y_aug):  # For Ito diagonal.
         y, adj_y, requires_grad = self._get_state(t, y_aug)
         with torch.enable_grad():
-            g = self._base_sde.g(-t, y)
-            g_dg_vjp, = misc.vjp(
-                outputs=g,
-                inputs=y,
-                grad_outputs=g,
-                allow_unused=True,
-                create_graph=True
-            )
-            # Double Stratonovich correction.
-            f = self._base_sde.f(-t, y) - g_dg_vjp
-            vjp_y_and_params = misc.vjp(
-                outputs=f,
-                inputs=[y] + self._params,
-                grad_outputs=adj_y,
-                allow_unused=True,
-                retain_graph=True,
-                create_graph=requires_grad
-            )
-            # Convert the adjoint Stratonovich SDE to Itô form.
-            a_dg_vjp, = misc.vjp(
-                outputs=g,
-                inputs=y,
-                grad_outputs=adj_y,
-                allow_unused=True,
-                retain_graph=True,
-                create_graph=requires_grad
-            )
-            extra_vjp_y_and_params = misc.vjp(
-                outputs=g,
-                inputs=[y] + self._params,
-                grad_outputs=a_dg_vjp,
-                allow_unused=True,
-                create_graph=requires_grad
-            )
-            vjp_y_and_params = misc.seq_add(vjp_y_and_params, extra_vjp_y_and_params)
-            if not requires_grad:
-                # See corresponding note in f_uncorrected.
-                f = f.detach()
-        return misc.flatten((-f, *vjp_y_and_params))
+            f, g = self._base_sde.f_and_g(-t, y)
+            return self._f_corrected_diagonal(f, g, y, adj_y, requires_grad)
 
     ########################################
     #                  g                   #
@@ -217,6 +258,23 @@ class AdjointSDE(base_sde.BaseSDE):
         raise RuntimeError("Adjoint `g` not defined. Please report a bug to torchsde.")
 
     ########################################
+    #               f_and_g                #
+    ########################################
+
+    def f_and_g(self, t, y):
+        # Like g above, this is inefficient to compute.
+        raise RuntimeError("Adjoint `f_and_g` not defined. Please report a bug to torchsde.")
+
+    ########################################
+    #                prod                  #
+    ########################################
+
+    def prod(self, g, v):
+        # We could define this just fine, but we don't expect to ever be able to compute the input `g`, so we should
+        # never get here.
+        raise RuntimeError("Adjoint `prod` not defined. Please report a bug to torchsde.")
+
+    ########################################
     #                g_prod                #
     ########################################
 
@@ -224,17 +282,40 @@ class AdjointSDE(base_sde.BaseSDE):
         y, adj_y, requires_grad = self._get_state(t, y_aug, v)
         with torch.enable_grad():
             g_prod = self._base_sde.g_prod(-t, y, v)
-            vjp_y_and_params = misc.vjp(
-                outputs=g_prod,
-                inputs=[y] + self._params,
-                grad_outputs=adj_y,
-                allow_unused=True,
-                create_graph=requires_grad
-            )
-            if not requires_grad:
-                # See corresponding note in f_uncorrected.
-                g_prod = g_prod.detach()
-        return misc.flatten((-g_prod, *vjp_y_and_params))
+            return self._g_prod(g_prod, y, adj_y, requires_grad)
+
+    ########################################
+    #            f_and_g_prod              #
+    ########################################
+
+    def f_and_g_prod_uncorrected(self, t, y_aug, v):  # For Ito additive and Stratonovich.
+        y, adj_y, requires_grad = self._get_state(t, y_aug)
+        with torch.enable_grad():
+            f, g_prod = self._base_sde.f_and_g_prod(-t, y)
+
+            f_out = self._f_uncorrected(f, y, adj_y, requires_grad)
+            g_prod_out = self._g_prod(g_prod, y, adj_y, requires_grad)
+            return f_out, g_prod_out
+
+    def f_and_g_prod_corrected_default(self, t, y_aug, v):  # For Ito general/scalar.
+        y, adj_y, requires_grad = self._get_state(t, y_aug)
+        with torch.enable_grad():
+            f, g = self._base_sde.f_and_g(-t, y)
+            g_prod = self._base_sde.prod(g, v)
+
+            f_out = self._f_corrected_default(f, g, y, adj_y, requires_grad)
+            g_prod_out = self._g_prod(g_prod, y, adj_y, requires_grad)
+            return f_out, g_prod_out
+
+    def f_and_g_prod_corrected_diagonal(self, t, y_aug, v):  # For Ito diagonal.
+        y, adj_y, requires_grad = self._get_state(t, y_aug)
+        with torch.enable_grad():
+            f, g = self._base_sde.f_and_g(-t, y)
+            g_prod = self._base_sde.prod(g, v)
+
+            f_out = self._f_corrected_diagonal(f, g, y, adj_y, requires_grad)
+            g_prod_out = self._g_prod(g_prod, y, adj_y, requires_grad)
+            return f_out, g_prod_out
 
     ########################################
     #               gdg_prod               #

--- a/torchsde/_core/adjoint_sde.py
+++ b/torchsde/_core/adjoint_sde.py
@@ -291,7 +291,7 @@ class AdjointSDE(base_sde.BaseSDE):
     def f_and_g_prod_uncorrected(self, t, y_aug, v):  # For Ito additive and Stratonovich.
         y, adj_y, requires_grad = self._get_state(t, y_aug)
         with torch.enable_grad():
-            f, g_prod = self._base_sde.f_and_g_prod(-t, y)
+            f, g_prod = self._base_sde.f_and_g_prod(-t, y, v)
 
             f_out = self._f_uncorrected(f, y, adj_y, requires_grad)
             g_prod_out = self._g_prod(g_prod, y, adj_y, requires_grad)

--- a/torchsde/_core/base_sde.py
+++ b/torchsde/_core/base_sde.py
@@ -48,10 +48,16 @@ class ForwardSDE(BaseSDE):
         # Register the core functions. This avoids polluting the codebase with if-statements and achieves speed-ups
         # by making sure it's a one-time cost.
 
+        if hasattr(sde, 'f_and_g_prod'):
+            self.f_and_g_prod = sde.f_and_g_prod
+        elif hasattr(sde, 'f') and hasattr(sde, 'g_prod'):
+            self.f_and_g_prod = self.f_and_g_prod_default1
+        else:
+            self.f_and_g_prod = self.f_and_g_prod_default2
+
         self.f = getattr(sde, 'f', self.f_default)
         self.g = getattr(sde, 'g', self.g_default)
         self.f_and_g = getattr(sde, 'f_and_g', self.f_and_g_default)
-        self.f_and_g_prod = getattr(sde, 'f_and_g_prod', self.f_and_g_prod_default)
         self.g_prod = getattr(sde, 'g_prod', self.g_prod_default)
         self.prod = {
             NOISE_TYPES.diagonal: self.prod_diagonal
@@ -103,10 +109,13 @@ class ForwardSDE(BaseSDE):
         return self.prod(self.g(t, y), v)
 
     ########################################
-    #            f_and_g_prod              #
+    #             f_and_g_prod             #
     ########################################
 
-    def f_and_g_prod_default(self, t, y, v):
+    def f_and_g_prod_default1(self, t, y, v):
+        return self.f(t, y), self.g_prod(t, y, v)
+
+    def f_and_g_prod_default2(self, t, y, v):
         f, g = self.f_and_g(t, y)
         return f, self.prod(g, v)
 

--- a/torchsde/_core/base_sde.py
+++ b/torchsde/_core/base_sde.py
@@ -44,14 +44,18 @@ class ForwardSDE(BaseSDE):
     def __init__(self, sde, fast_dg_ga_jvp_column_sum=False):
         super(ForwardSDE, self).__init__(sde_type=sde.sde_type, noise_type=sde.noise_type)
         self._base_sde = sde
-        self.f = sde.f
-        self.g = sde.g
 
         # Register the core functions. This avoids polluting the codebase with if-statements and achieves speed-ups
         # by making sure it's a one-time cost.
-        self.g_prod = {
-            NOISE_TYPES.diagonal: self.g_prod_diagonal,
-        }.get(sde.noise_type, self.g_prod_default)
+
+        self.f = getattr(sde, 'f', self.f_default)
+        self.g = getattr(sde, 'g', self.g_default)
+        self.f_and_g = getattr(sde, 'f_and_g', self.f_and_g_default)
+        self.f_and_g_prod = getattr(sde, 'f_and_g_prod', self.f_and_g_prod_default)
+        self.g_prod = getattr(sde, 'g_prod', self.g_prod_default)
+        self.prod = {
+            NOISE_TYPES.diagonal: self.prod_diagonal
+        }.get(sde.noise_type, self.prod_default)
         self.gdg_prod = {
             NOISE_TYPES.diagonal: self.gdg_prod_diagonal,
             NOISE_TYPES.additive: self._return_zero,
@@ -63,14 +67,48 @@ class ForwardSDE(BaseSDE):
         }.get(sde.noise_type, self._return_zero)
 
     ########################################
+    #                  f                   #
+    ########################################
+    def f_default(self, t, y):
+        raise RuntimeError("Method `f` has not provided, but is required.")
+
+    ########################################
+    #                  g                   #
+    ########################################
+    def g_default(self, t, y):
+        raise RuntimeError("Method `g` has not provided, but is required.")
+
+    ########################################
+    #               f_and_g                #
+    ########################################
+
+    def f_and_g_default(self, t, y):
+        return self.f(t, y), self.g(t, y)
+
+    ########################################
+    #                prod                  #
+    ########################################
+
+    def prod_diagonal(self, g, v):
+        return g * v
+
+    def prod_default(self, g, v):
+        return misc.batch_mvp(g, v)
+
+    ########################################
     #                g_prod                #
     ########################################
 
-    def g_prod_diagonal(self, t, y, v):
-        return self.g(t, y) * v
-
     def g_prod_default(self, t, y, v):
-        return misc.batch_mvp(self.g(t, y), v)
+        return self.prod(self.g(t, y), v)
+
+    ########################################
+    #            f_and_g_prod              #
+    ########################################
+
+    def f_and_g_prod_default(self, t, y, v):
+        f, g = self.f_and_g(t, y)
+        return f, self.prod(g, v)
 
     ########################################
     #               gdg_prod               #
@@ -159,18 +197,16 @@ class ForwardSDE(BaseSDE):
 
 class RenameMethodsSDE(BaseSDE):
 
-    def __init__(self, sde, drift='f', diffusion='g', prior_drift='h'):
+    def __init__(self, sde, drift='f', diffusion='g', prior_drift='h', diffusion_prod='g_prod',
+                 drift_and_diffusion='f_and_g', drift_and_diffusion_prod='f_and_g_prod'):
         super(RenameMethodsSDE, self).__init__(noise_type=sde.noise_type, sde_type=sde.sde_type)
         self._base_sde = sde
-        self.f = getattr(sde, drift)
-        self.g = getattr(sde, diffusion)
-
-        # Prevents raising an error when logqp is disabled and `sde` doesn't have an attribute for `h`.
-        # Functions that raise exceptions cannot be simply rewritten as lambda functions; therefore using `def`.
-        def default_h(*args, **kwargs):
-            raise AttributeError(f"'{type(self)}' object has no attribute '{prior_drift}'")
-
-        self.h = getattr(sde, prior_drift, default_h)
+        for name, value in zip(('f', 'g', 'h', 'g_prod', 'f_and_g', 'f_and_g_prod'),
+                               (drift, diffusion, prior_drift, diffusion_prod, drift_and_diffusion, drift_and_diffusion_prod)):
+            try:
+                setattr(self, name, getattr(sde, value))
+            except AttributeError:
+                pass
 
 
 class SDEIto(BaseSDE):
@@ -193,17 +229,24 @@ class SDELogqp(BaseSDE):
         self._base_sde = sde
 
         # Make this redirection a one-time cost.
-        self._base_f = sde.f
-        self._base_g = sde.g
-        self._base_h = sde.h
+        try:
+            self._base_f = sde.f
+            self._base_g = sde.g
+            self._base_h = sde.h
+        except AttributeError as e:
+            # TODO: relax this requirement, and use f_and_g, f_and_g_prod, f_and_g_and_h and f_and_g_prod_and_h if
+            #  they're available.
+            raise AttributeError("If using logqp then drift, diffusion and prior drift must all be specified.") from e
 
         # Make this method selection a one-time cost.
         if sde.noise_type == NOISE_TYPES.diagonal:
             self.f = self.f_diagonal
             self.g = self.g_diagonal
+            self.f_and_g = self.f_and_g_diagonal
         else:
             self.f = self.f_general
             self.g = self.g_general
+            self.f_and_g = self.f_and_g_general
 
     def f_diagonal(self, t, y: Tensor):
         y = y[:, :-1]
@@ -218,6 +261,14 @@ class SDELogqp(BaseSDE):
         g_logqp = y.new_zeros(size=(y.size(0), 1))
         return torch.cat([g, g_logqp], dim=1)
 
+    def f_and_g_diagonal(self, t, y: Tensor):
+        y = y[:, :-1]
+        f, g, h = self._base_f(t, y), self._base_g(t, y), self._base_h(t, y)
+        u = misc.stable_division(f - h, g)
+        f_logqp = .5 * (u ** 2).sum(dim=1, keepdim=True)
+        g_logqp = y.new_zeros(size=(y.size(0), 1))
+        return torch.cat([f, f_logqp], dim=1), torch.cat([g, g_logqp], dim=1)
+
     def f_general(self, t, y: Tensor):
         y = y[:, :-1]
         f, g, h = self._base_f(t, y), self._base_g(t, y), self._base_h(t, y)
@@ -230,4 +281,12 @@ class SDELogqp(BaseSDE):
         g = self._base_sde.g(t, y)
         g_logqp = y.new_zeros(size=(g.size(0), 1, g.size(-1)))
         return torch.cat([g, g_logqp], dim=1)
+
+    def f_and_g_general(self, t, y: Tensor):
+        y = y[:, :-1]
+        f, g, h = self._base_f(t, y), self._base_g(t, y), self._base_h(t, y)
+        u = misc.batch_mvp(g.pinverse(), f - h)  # (batch_size, brownian_size).
+        f_logqp = .5 * (u ** 2).sum(dim=1, keepdim=True)
+        g_logqp = y.new_zeros(size=(g.size(0), 1, g.size(-1)))
+        return torch.cat([f, f_logqp], dim=1), torch.cat([g, g_logqp], dim=1)
 # ----------------------------------------

--- a/torchsde/_core/methods/euler.py
+++ b/torchsde/_core/methods/euler.py
@@ -30,8 +30,7 @@ class Euler(base_solver.BaseSDESolver):
         dt = t1 - t0
         I_k = self.bm(t0, t1)
 
-        f = self.sde.f(t0, y0)
-        g_prod = self.sde.g_prod(t0, y0, I_k)
+        f, g_prod = self.sde.f_and_g_prod(t0, y0, I_k)
 
         y1 = y0 + f * dt + g_prod
         return y1

--- a/torchsde/_core/methods/euler_heun.py
+++ b/torchsde/_core/methods/euler_heun.py
@@ -30,8 +30,7 @@ class EulerHeun(base_solver.BaseSDESolver):
         dt = t1 - t0
         I_k = self.bm(t0, t1)
 
-        f = self.sde.f(t0, y0)
-        g_prod = self.sde.g_prod(t0, y0, I_k)
+        f, g_prod = self.sde.f_and_g_prod(t0, y0, I_k)
 
         y_prime = y0 + g_prod
 

--- a/torchsde/_core/methods/heun.py
+++ b/torchsde/_core/methods/heun.py
@@ -36,13 +36,11 @@ class Heun(base_solver.BaseSDESolver):
         dt = t1 - t0
         I_k = self.bm(t0, t1)
 
-        f = self.sde.f(t0, y0)
-        g_prod = self.sde.g_prod(t0, y0, I_k)
+        f, g_prod = self.sde.f_and_g_prod(t0, y0, I_k)
 
         y0_prime = y0 + dt * f + g_prod
 
-        f_prime = self.sde.f(t1, y0_prime)
-        g_prod_prime = self.sde.g_prod(t1, y0_prime, I_k)
+        f_prime, g_prod_prime = self.sde.f_and_g_prod(t1, y0_prime, I_k)
 
         y1 = y0 + (dt * (f + f_prime) + g_prod + g_prod_prime) * 0.5
 

--- a/torchsde/_core/methods/log_ode.py
+++ b/torchsde/_core/methods/log_ode.py
@@ -47,7 +47,7 @@ class LogODEMidpoint(base_solver.BaseSDESolver):
         t_prime = t0 + half_dt
         y_prime = y0 + half_dt * f + .5 * g_prod
 
-        f_prime, g_prod_prime = self.sde.f(t_prime, y_prime, I_k)
+        f_prime, g_prod_prime = self.sde.f_and_g_prod(t_prime, y_prime, I_k)
         dg_ga_prime = self.sde.dg_ga_jvp_column_sum(t_prime, y_prime, A)
 
         y1 = y0 + dt * f_prime + g_prod_prime + dg_ga_prime

--- a/torchsde/_core/methods/log_ode.py
+++ b/torchsde/_core/methods/log_ode.py
@@ -40,16 +40,14 @@ class LogODEMidpoint(base_solver.BaseSDESolver):
         dt = t1 - t0
         I_k, A = self.bm(t0, t1, return_A=True)
 
-        f = self.sde.f(t0, y0)
-        g_prod = self.sde.g_prod(t0, y0, I_k)
+        f, g_prod = self.sde.f_and_g_prod(t0, y0, I_k)
 
         half_dt = 0.5 * dt
 
         t_prime = t0 + half_dt
         y_prime = y0 + half_dt * f + .5 * g_prod
 
-        f_prime = self.sde.f(t_prime, y_prime)
-        g_prod_prime = self.sde.g_prod(t_prime, y_prime, I_k)
+        f_prime, g_prod_prime = self.sde.f(t_prime, y_prime, I_k)
         dg_ga_prime = self.sde.dg_ga_jvp_column_sum(t_prime, y_prime, A)
 
         y1 = y0 + dt * f_prime + g_prod_prime + dg_ga_prime

--- a/torchsde/_core/methods/midpoint.py
+++ b/torchsde/_core/methods/midpoint.py
@@ -30,16 +30,14 @@ class Midpoint(base_solver.BaseSDESolver):
         dt = t1 - t0
         I_k = self.bm(t0, t1)
 
-        f = self.sde.f(t0, y0)
-        g_prod = self.sde.g_prod(t0, y0, I_k)
+        f, g_prod = self.sde.f_and_g_prod(t0, y0, I_k)
 
         half_dt = 0.5 * dt
 
         t_prime = t0 + half_dt
         y_prime = y0 + half_dt * f + 0.5 * g_prod
 
-        f_prime = self.sde.f(t_prime, y_prime)
-        g_prod_prime = self.sde.g_prod(t_prime, y_prime, I_k)
+        f_prime, g_prod_prime = self.sde.f_and_g_prod(t_prime, y_prime, I_k)
 
         y1 = y0 + dt * f_prime + g_prod_prime
 

--- a/torchsde/_core/methods/milstein.py
+++ b/torchsde/_core/methods/milstein.py
@@ -54,13 +54,12 @@ class BaseMilstein(base_solver.BaseSDESolver, metaclass=abc.ABCMeta):
         I_k = self.bm(t0, t1)
         v = self.v_term(I_k, dt)
 
-        f = self.sde.f(t0, y0)
-        g_prod_I_k = self.sde.g_prod(t0, y0, I_k)
+        f, g_prod_I_k = self.sde.f_and_g_prod(t0, y0, I_k)
 
         if self.options[METHOD_OPTIONS.grad_free]:
             g = self.sde.g(t0, y0)
             g = g.squeeze(2) if g.dim() == 3 else g
-            g_prod_v = self.sde.g_prod(t0, y0, v)
+            g_prod_v = self.sde.prod(g, v)
             sqrt_dt = dt.sqrt()
             y0_prime = y0 + self.y_prime_f_factor(dt, f) + g * sqrt_dt
             g_prod_v_prime = self.sde.g_prod(t0, y0_prime, v)

--- a/torchsde/_core/methods/milstein.py
+++ b/torchsde/_core/methods/milstein.py
@@ -54,17 +54,18 @@ class BaseMilstein(base_solver.BaseSDESolver, metaclass=abc.ABCMeta):
         I_k = self.bm(t0, t1)
         v = self.v_term(I_k, dt)
 
-        f = self.sde.f(t0, y0)
-
         if self.options[METHOD_OPTIONS.grad_free]:
-            g = self.sde.g(t0, y0)
-            g_prod_I_k = self.sde.prod(g, I_k)
+            f, g = self.sde.f_and_g(t0, y0)
             g_ = g.squeeze(2) if g.dim() == 3 else g  # scalar noise vs diagonal noise
             sqrt_dt = dt.sqrt()
+            # TODO: This y_prime_f_factor looks unnecessary: whether it's there or not we get the correct Taylor
+            #  expansion. I've (Patrick) not been able to find a reference making clear why it's sometimes included.
             y0_prime = y0 + self.y_prime_f_factor(dt, f) + g_ * sqrt_dt
             g_prime = self.sde.g(t0, y0_prime)
+            g_prod_I_k = self.sde.prod(g, I_k)
             gdg_prod = self.sde.prod(g_prime - g, v) / (2 * sqrt_dt)
         else:
+            f = self.sde.f(t0, y0)
             g_prod_I_k, gdg_prod = self.sde.g_prod_and_gdg_prod(t0, y0, I_k, 0.5 * v)
 
         y1 = y0 + f * dt + g_prod_I_k + gdg_prod

--- a/torchsde/_core/methods/milstein.py
+++ b/torchsde/_core/methods/milstein.py
@@ -54,20 +54,20 @@ class BaseMilstein(base_solver.BaseSDESolver, metaclass=abc.ABCMeta):
         I_k = self.bm(t0, t1)
         v = self.v_term(I_k, dt)
 
-        f, g_prod_I_k = self.sde.f_and_g_prod(t0, y0, I_k)
+        f = self.sde.f(t0, y0)
 
         if self.options[METHOD_OPTIONS.grad_free]:
             g = self.sde.g(t0, y0)
-            g = g.squeeze(2) if g.dim() == 3 else g
-            g_prod_v = self.sde.prod(g, v)
+            g_prod_I_k = self.sde.prod(g, I_k)
+            g_ = g.squeeze(2) if g.dim() == 3 else g  # scalar noise vs diagonal noise
             sqrt_dt = dt.sqrt()
-            y0_prime = y0 + self.y_prime_f_factor(dt, f) + g * sqrt_dt
-            g_prod_v_prime = self.sde.g_prod(t0, y0_prime, v)
-            gdg_prod = (g_prod_v_prime - g_prod_v) / sqrt_dt
+            y0_prime = y0 + self.y_prime_f_factor(dt, f) + g_ * sqrt_dt
+            g_prime = self.sde.g(t0, y0_prime)
+            gdg_prod = self.sde.prod(g_prime - g, v) / (2 * sqrt_dt)
         else:
-            gdg_prod = self.sde.gdg_prod(t0, y0, v)
+            g_prod_I_k, gdg_prod = self.sde.g_prod_and_gdg_prod(t0, y0, I_k, v)
 
-        y1 = y0 + f * dt + g_prod_I_k + .5 * gdg_prod
+        y1 = y0 + f * dt + g_prod_I_k + gdg_prod
 
         return y1
 

--- a/torchsde/_core/methods/milstein.py
+++ b/torchsde/_core/methods/milstein.py
@@ -65,7 +65,7 @@ class BaseMilstein(base_solver.BaseSDESolver, metaclass=abc.ABCMeta):
             g_prime = self.sde.g(t0, y0_prime)
             gdg_prod = self.sde.prod(g_prime - g, v) / (2 * sqrt_dt)
         else:
-            g_prod_I_k, gdg_prod = self.sde.g_prod_and_gdg_prod(t0, y0, I_k, v)
+            g_prod_I_k, gdg_prod = self.sde.g_prod_and_gdg_prod(t0, y0, I_k, 0.5 * v)
 
         y1 = y0 + f * dt + g_prod_I_k + gdg_prod
 

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -202,12 +202,20 @@ def check_contract(sde, y0, ts, bm, method, names, logqp):
         _check_2d_or_3d('Diffusion', g_diffusion_shape)
     if hasattr(sde, 'g_prod'):
         has_g = True
-        g_prod_shape = tuple(sde.g_prod(ts[0], y0).size())
+        if len(noise_sizes) == 0:
+            raise ValueError("Cannot infer noise size (i.e. number of Brownian motion channels). Either pass `bm` "
+                             "explicitly, or specify one of the `g`, `f_and_g` functions.`")
+        v = torch.randn(batch_sizes[0], noise_sizes[0], dtype=y0.dtype, device=y0.device)
+        g_prod_shape = tuple(sde.g_prod(ts[0], y0, v).size())
         _check_2d('Diffusion-vector product', g_prod_shape)
     if hasattr(sde, 'f_and_g_prod'):
         has_f = True
         has_g = True
-        _f, _g_prod = sde.f_and_g_prod(ts[0], y0)
+        if len(noise_sizes) == 0:
+            raise ValueError("Cannot infer noise size (i.e. number of Brownian motion channels). Either pass `bm` "
+                             "explicitly, or specify one of the `g`, `f_and_g` functions.`")
+        v = torch.randn(batch_sizes[0], noise_sizes[0], dtype=y0.dtype, device=y0.device)
+        _f, _g_prod = sde.f_and_g_prod(ts[0], y0, v)
         f_drift_shape = tuple(_f.size())
         g_prod_shape = tuple(_g_prod.size())
         _check_2d('Drift', f_drift_shape)

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -174,6 +174,7 @@ def check_contract(sde, y0, ts, bm, method, names, logqp):
                 raise ValueError(f"{name} must be of shape (batch, state_channels), but got {shape}.")
             batch_sizes.append(shape[0])
             state_sizes.append(shape[1])
+            noise_sizes.append(shape[1])
         else:
             if len(shape) != 3:
                 raise ValueError(f"{name} must be of shape (batch, state_channels, noise_channels), but got {shape}.")

--- a/torchsde/_core/sdeint.py
+++ b/torchsde/_core/sdeint.py
@@ -249,4 +249,4 @@ def integrate(sde, y0, ts, bm, method, dt, adaptive, rtol, atol, dt_min, options
         return ys, log_ratio_increments
     # ----------------------------------------
 
-    return solver.integrate(ts)
+    return ys


### PR DESCRIPTION
Heyhey. I've been tweaking some of the SDE-GAN stuff (for the paper, not the example), and realised that it could be made much more efficient with library support... and what's the point of being a developer of the library if not for that?

- Major bugfix: fixed calling `solver.integrate` twice in `sdeint.py::integrate` (!) (I can make this a separate PR if you want to put this in immediately.)
- Added `f_and_g`, `g_prod`, and `f_and_g_prod` as functions that the SDE can define, which will be used in the solvers if possible. `f` and `g` no longer actually have to be defined if the solver doesn't need them. [1]
- Improved efficiency:
    - logqp=True now takes advantage of this to define an `f_and_g` function that is more efficient than calling them separately. (Unrelated to what I'm doing, but why not.) [2]
    - Milstein and derivative-free Milstein now no longer have extra `g` computations.
- Improved the error checking in check_contract to explicitly require a single batch dimension.

(N.B. This PR depends upon #85.)

[1] My use case for this: First of all, I'd like drift and diffusion to just be different final layers at the end of the same MLP, hence `f_and_g`. Second, for the discriminator, the diffusion ends up being a product of matrices. Doing (matrix-matrix)-vector would be inefficient, hence `g_prod`/`f_and_g_prod`.

[2] There's still some improvements that could be made here: for simplicity logqp still requires `f`/`g`/`h` to all be specified, without exploiting `f_and_g` or `f_and_g_prod` if they're available. The logical extension of this would be to also add `f_and_g_and_h`, `f_and_g_prod_and_h` as possible methods.