### PR TITLE
Extend CI workflow to include PyPI dist publishing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -92,3 +92,14 @@ jobs:
           python setup.py develop
           cd ..
           pytest torchsde/tests
+
+      - name: Build
+        run: >-
+          python setup.py sdist bdist_wheel
+
+      - name: Publish to PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -103,3 +103,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
+


### PR DESCRIPTION
Minor PR, title says it all.

Publishing is triggered only by release events. To work, the addition requires setup of a PyPI password in repo secrets.

Addresses [this](https://github.com/google-research/torchsde/issues/96).