### PR TITLE
Fix incorrectly formatted version rules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['benchmarks', 'diagnostics', 'examples', 'tests']),
     install_requires=[
         "boltons>=20.2.1",
-        "numpy==1.19.*;python_version<'3.7'",
+        "numpy==1.19;python_version<'3.7'",
         "numpy>=1.19;python_version>='3.7'",
-        "scipy==1.5.*;python_version<'3.7'",
+        "scipy==1.5;python_version<'3.7'",
         "scipy>=1.5;python_version>='3.7'",
         "torch>=1.6.0",
         "trampoline>=0.1.2",


### PR DESCRIPTION
## Related issue number
- Issue: #131

## Description
Fix incorrectly formatted version rules.
- Remove the .* at line18 numpy>=1.19.*