### PR TITLE
bump version number

### DIFF
--- a/torchsde/__init__.py
+++ b/torchsde/__init__.py
@@ -24,4 +24,4 @@ BrownianTree.__init__.__annotations__ = {}
 sdeint.__annotations__ = {}
 sdeint_adjoint.__annotations__ = {}
 
-__version__ = '0.2.5'
+__version__ = '0.2.6'


### PR DESCRIPTION
bumps version number of torchsde package so it can be used to create a new release and published to pypi.
see #131 for details