### PR TITLE
Kornia library compatibulity

### DIFF
--- a/examples/unet.py
+++ b/examples/unet.py
@@ -147,7 +147,7 @@ class Blur(nn.Module):
         self.register_buffer('f', f)
 
     def forward(self, x):
-        return kornia.filter2D(x, self.f, normalized=True)
+        return kornia.filters.filter2d(x, self.f, normalized=True)
 
 
 class Downsample(nn.Module):


### PR DESCRIPTION
kornia library has refactored some functions and the example/cont_ddpm.py was not working anymore due to an error raised 
 in example/unet.py  that needs to be changed to `return kornia.filters.filter2d(x, self.f, normalized=True)`.