### PR TITLE
Update brownian_interval.py to allow torchsde to use torch_xla

### DIFF
--- a/torchsde/_brownian/brownian_interval.py
+++ b/torchsde/_brownian/brownian_interval.py
@@ -28,7 +28,7 @@ _r12 = 1 / 12
 
 
 def _randn(size, dtype, device, seed):
-    generator = torch.Generator(device).manual_seed(int(seed))
+    generator = torch.Generator().manual_seed(int(seed))
     return torch.randn(size, dtype=dtype, device=device, generator=generator)
 
 


### PR DESCRIPTION
Update brownian_interval.py to allow torchsde to use torch_xla, torch.Generator('xla') is not working